### PR TITLE
Extract WebviewHtmlGenerator and AssetLoader from GitGraphView

### DIFF
--- a/src/assetLoader.ts
+++ b/src/assetLoader.ts
@@ -1,0 +1,14 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+export class AssetLoader {
+	private extensionPath: string;
+
+	constructor(extensionPath: string) {
+		this.extensionPath = extensionPath;
+	}
+
+	getUri(...pathComps: string[]) {
+		return vscode.Uri.file(path.join(this.extensionPath, ...pathComps));
+	}
+}

--- a/src/avatarManager.ts
+++ b/src/avatarManager.ts
@@ -46,7 +46,7 @@ export class AvatarManager {
 			}
 			if (this.avatars[email].image !== null) {
 				// Avatar image is available
-				this.sendAvatarToWebView(email, () => {
+				this.sendAvatarToWebview(email, () => {
 					// Avatar couldn't be found, request it again
 					this.removeAvatarFromCache(email);
 					this.queue.add(email, repo, commits, true);
@@ -270,10 +270,10 @@ export class AvatarManager {
 			this.avatars[email] = { image: image, timestamp: (new Date()).getTime(), identicon: identicon };
 		}
 		this.extensionState.saveAvatar(email, this.avatars[email]);
-		this.sendAvatarToWebView(email, () => { });
+		this.sendAvatarToWebview(email, () => { });
 	}
 
-	private sendAvatarToWebView(email: string, onError: () => void) {
+	private sendAvatarToWebview(email: string, onError: () => void) {
 		if (this.view !== null) {
 			fs.readFile(this.avatarStorageFolder + '/' + this.avatars[email].image, (err, data) => {
 				if (err) {

--- a/src/webviewHtmlGenerator.ts
+++ b/src/webviewHtmlGenerator.ts
@@ -1,0 +1,75 @@
+import { GitGraphViewState } from './types';
+import { AssetLoader } from './assetLoader';
+
+export class WebviewHtmlGenerator {
+  private viewState: GitGraphViewState;
+  private assetLoader: AssetLoader;
+
+	constructor(assetLoader: AssetLoader, viewState: GitGraphViewState) {
+    this.assetLoader = assetLoader;
+		this.viewState = viewState;
+	}
+
+	public getHtmlForWebview() {
+		const nonce = getNonce();
+		let body, numRepos = Object.keys(this.viewState.repos).length, colorVars = '', colorParams = '';
+		for (let i = 0; i < this.viewState.graphColours.length; i++) {
+			colorVars += '--git-graph-color' + i + ':' + this.viewState.graphColours[i] + '; ';
+			colorParams += '[data-color="' + i + '"]{--git-graph-color:var(--git-graph-color' + i + ');} ';
+		}
+		if (numRepos > 0) {
+			body = `<body style="${colorVars}">
+			<div id="controls">
+				<span id="repoControl"><span class="unselectable">Repo: </span><div id="repoSelect" class="dropdown"></div></span>
+				<span id="branchControl"><span class="unselectable">Branch: </span><div id="branchSelect" class="dropdown"></div></span>
+				<label id="showRemoteBranchesControl"><input type="checkbox" id="showRemoteBranchesCheckbox" value="1" checked>Show Remote Branches</label>
+				<div id="refreshBtn" class="roundedBtn">Refresh</div>
+			</div>
+			<div id="content">
+				<div id="commitGraph"></div>
+				<div id="commitTable"></div>
+			</div>
+			<div id="footer"></div>
+			<ul id="contextMenu"></ul>
+			<div id="dialogBacking"></div>
+			<div id="dialog"></div>
+			<div id="scrollShadow"></div>
+			<script nonce="${nonce}">var viewState = ${JSON.stringify(this.viewState)};</script>
+			<script src="${this.getMediaUri('out.min.js')}"></script>
+			</body>`;
+		} else {
+			body = `<body class="unableToLoad" style="${colorVars}">
+			<h2>Unable to load Git Graph</h2>
+			<p>Either the current workspace does not contain a Git repository, or the Git executable could not be found.</p>
+			<p>If you are using a portable Git installation, make sure you have set the Visual Studio Code Setting "git.path" to the path of your portable installation (e.g. "C:\\Program Files\\Git\\bin\\git.exe" on Windows).</p>
+			</body>`;
+		}
+
+		return `<!DOCTYPE html>
+		<html lang="en">
+			<head>
+				<meta charset="UTF-8">
+				<meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src vscode-resource: 'unsafe-inline'; script-src vscode-resource: 'nonce-${nonce}'; img-src data:;">
+				<meta name="viewport" content="width=device-width, initial-scale=1.0">
+				<link rel="stylesheet" type="text/css" href="${this.getMediaUri('main.css')}">
+				<link rel="stylesheet" type="text/css" href="${this.getMediaUri('dropdown.css')}">
+				<title>Git Graph</title>
+				<style>${colorParams}"</style>
+			</head>
+			${body}
+		</html>`;
+	}
+
+	private getMediaUri(file: string) {
+		return this.assetLoader.getUri('media', file).with({ scheme: 'vscode-resource' });
+	}
+}
+
+function getNonce() {
+	let text = '';
+	const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+	for (let i = 0; i < 32; i++) {
+		text += possible.charAt(Math.floor(Math.random() * possible.length));
+	}
+	return text;
+}

--- a/web/global.d.ts
+++ b/web/global.d.ts
@@ -2,9 +2,9 @@ import * as GG from "../out/types";
 
 declare global {
 	function acquireVsCodeApi(): {
-		getState(): WebViewState | null,
+		getState(): WebviewState | null,
 		postMessage(message: GG.RequestMessage): void,
-		setState(state: WebViewState): void
+		setState(state: WebviewState): void
 	};
 
 	var viewState: GG.GitGraphViewState;
@@ -106,7 +106,7 @@ declare global {
 
 	type AvatarImageCollection = { [email: string]: string };
 
-	interface WebViewState {
+	interface WebviewState {
 		gitRepos: GG.GitRepoSet;
 		gitBranches: string[];
 		gitBranchHead: string | null;

--- a/web/main.ts
+++ b/web/main.ts
@@ -26,7 +26,7 @@ class GitGraphView {
 	private loadBranchesCallback: ((changes: boolean, isRepo: boolean) => void) | null = null;
 	private loadCommitsCallback: ((changes: boolean) => void) | null = null;
 
-	constructor(repos: GG.GitRepoSet, lastActiveRepo: string | null, config: Config, prevState: WebViewState | null) {
+	constructor(repos: GG.GitRepoSet, lastActiveRepo: string | null, config: Config, prevState: WebviewState | null) {
 		this.gitRepos = repos;
 		this.config = config;
 		this.maxCommits = config.initialLoadCommits;


### PR DESCRIPTION
Summary:

I wanted to minimalize the required dependencies to render the HTML for the Git Graph Webview.
This would allow me to pass any object as a state to `WebviewHtmlGenerator` so that I can test this outside of VS Code (in actual tests).

I also extracted `AssetLoader` (`getUri`) so that I can use it both within `GitGraphView` and `WebviewHtmlGenerator`.

I also renamed `webView` to `webview` across the project for consistency with what VS Code API uses: https://code.visualstudio.com/api/extension-guides/webview