### PR TITLE
Add gitmoji support and autolinking to commit messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -332,5 +332,8 @@
 		"typescript": "^3.3.1",
 		"uglify-js": "^3.4.9",
 		"vscode": "^1.1.28"
+	},
+	"dependencies": {
+		"autolinker": "^3.1.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,11 @@
 					"default": true,
 					"description": "Automatically center the commit details view when it is opened."
 				},
+				"git-graph.autoLinkUrlsInCommitMessages": {
+					"type": "boolean",
+					"default": true,
+					"description": "Automatically recognize urls in commit messages and turn them into clickable links."
+				},
 				"git-graph.combineLocalAndRemoteBranchLabels": {
 					"type": "boolean",
 					"default": true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,10 @@ class Config {
 		return this.workspaceConfiguration.get('autoCenterCommitDetailsView', true);
 	}
 
+	public autoLinkUrlsInCommitMessages() {
+		return this.workspaceConfiguration.get('autoLinkUrlsInCommitMessages', true);
+	}
+
 	public combineLocalAndRemoteBranchLabels() {
 		return this.workspaceConfiguration.get('combineLocalAndRemoteBranchLabels', true);
 	}

--- a/src/dataSource.ts
+++ b/src/dataSource.ts
@@ -1,7 +1,7 @@
 import * as cp from 'child_process';
 import { getConfig } from './config';
 import { DiffSide, GitBranchData, GitCommandError, GitCommit, GitCommitComparisonData, GitCommitData, GitCommitDetails, GitCommitNode, GitFileChange, GitFileChangeType, GitRefData, GitResetMode, GitUnsavedChanges, RebaseOnType } from './types';
-import { abbrevCommit, getPathFromStr, runCommandInNewTerminal, UNCOMMITTED } from './utils';
+import { abbrevCommit, getPathFromStr, prepareCommitMesage, runCommandInNewTerminal, UNCOMMITTED } from './utils';
 
 const eolRegex = /\r\n|\r|\n/g;
 const headRegex = /^\(HEAD detached at [0-9A-Za-z]+\)/g;
@@ -96,7 +96,17 @@ export class DataSource {
 
 				for (i = 0; i < commits.length; i++) {
 					commitLookup[commits[i].hash] = i;
-					commitNodes.push({ hash: commits[i].hash, parentHashes: commits[i].parentHashes, author: commits[i].author, email: commits[i].email, date: commits[i].date, message: commits[i].message, heads: [], tags: [], remotes: [] });
+					commitNodes.push({
+						hash: commits[i].hash,
+						parentHashes: commits[i].parentHashes,
+						author: commits[i].author,
+						email: commits[i].email,
+						date: commits[i].date,
+						message: prepareCommitMesage(commits[i].message),
+						heads: [],
+						tags: [],
+						remotes: []
+					});
 				}
 				for (i = 0; i < refData.heads.length; i++) {
 					if (typeof commitLookup[refData.heads[i].hash] === 'number') commitNodes[commitLookup[refData.heads[i].hash]].heads.push(refData.heads[i].name);
@@ -137,7 +147,7 @@ export class DataSource {
 							email: commitInfo[3],
 							date: parseInt(commitInfo[4]),
 							committer: commitInfo[5],
-							body: lines.slice(1, lastLine + 1).join('\n'),
+							body: prepareCommitMesage(lines.slice(1, lastLine + 1).join('\n')),
 							fileChanges: [], error: null
 						});
 					}

--- a/src/gitmojis.json
+++ b/src/gitmojis.json
@@ -1,0 +1,437 @@
+{
+	"gitmojis":[
+		{
+			"emoji":"🎨",
+			"entity":"&#x1f3a8;",
+			"code":":art:",
+			"description":"Improving structure / format of the code.",
+			"name":"art"
+		},
+		{
+			"emoji":"⚡️",
+			"entity":"&#x26a1;",
+			"code":":zap:",
+			"description":"Improving performance.",
+			"name":"zap"
+		},
+		{
+			"emoji":"🔥",
+			"entity":"&#x1f525;",
+			"code":":fire:",
+			"description":"Removing code or files.",
+			"name":"fire"
+		},
+		{
+			"emoji":"🐛",
+			"entity":"&#x1f41b;",
+			"code":":bug:",
+			"description":"Fixing a bug.",
+			"name":"bug"
+		},
+		{
+			"emoji": "🚑",
+			"entity": "&#128657;",
+			"code": ":ambulance:",
+			"description": "Critical hotfix.",
+			"name": "ambulance"
+		},
+		{
+			"emoji":"✨",
+			"entity":"&#x2728;",
+			"code":":sparkles:",
+			"description":"Introducing new features.",
+			"name":"sparkles"
+		},
+		{
+			"emoji":"📝",
+			"entity":"&#x1f4dd;",
+			"code":":pencil:",
+			"description":"Writing docs.",
+			"name":"pencil"
+		},
+		{
+			"emoji":"🚀",
+			"entity":"&#x1f680;",
+			"code":":rocket:",
+			"description":"Deploying stuff.",
+			"name":"rocket"
+		},
+		{
+			"emoji":"💄",
+			"entity":"&#ff99cc;",
+			"code":":lipstick:",
+			"description":"Updating the UI and style files.",
+			"name":"lipstick"
+		},
+		{
+			"emoji":"🎉",
+			"entity":"&#127881;",
+			"code":":tada:",
+			"description":"Initial commit.",
+			"name":"tada"
+		},
+		{
+			"emoji":"✅",
+			"entity":"&#x2705;",
+			"code":":white_check_mark:",
+			"description":"Updating tests.",
+			"name":"white-check-mark"
+		},
+		{
+			"emoji":"🔒",
+			"entity":"&#x1f512;",
+			"code":":lock:",
+			"description":"Fixing security issues.",
+			"name":"lock"
+		},
+		{
+			"emoji":"🍎",
+			"entity":"&#x1f34e;",
+			"code":":apple:",
+			"description":"Fixing something on macOS.",
+			"name":"apple"
+		},
+		{
+			"emoji":"🐧",
+			"entity":"&#x1f427;",
+			"code":":penguin:",
+			"description":"Fixing something on Linux.",
+			"name":"penguin"
+		},
+		{
+			"emoji":"🏁",
+			"entity":"&#x1f3c1;",
+			"code":":checkered_flag:",
+			"description":"Fixing something on Windows.",
+			"name":"checkered-flag"
+		},
+		{
+			"emoji":"🤖",
+			"entity":"&#129302;",
+			"code":":robot:",
+			"description":"Fixing something on Android.",
+			"name":"robot"
+		},
+		{
+			"emoji":"🍏",
+			"entity":"&#127823;",
+			"code":":green_apple:",
+			"description":"Fixing something on iOS.",
+			"name":"green-apple"
+		},
+		{
+			"emoji":"🔖",
+			"entity":"&#x1f516;",
+			"code":":bookmark:",
+			"description":"Releasing / Version tags.",
+			"name":"bookmark"
+		},
+		{
+			"emoji":"🚨",
+			"entity":"&#x1f6a8;",
+			"code":":rotating_light:",
+			"description":"Removing linter warnings.",
+			"name":"rotating-light"
+		},
+		{
+			"emoji":"🚧",
+			"entity":"&#x1f6a7;",
+			"code":":construction:",
+			"description":"Work in progress.",
+			"name":"construction"
+		},
+		{
+			"emoji":"💚",
+			"entity":"&#x1f49a;",
+			"code":":green_heart:",
+			"description":"Fixing CI Build.",
+			"name":"green-heart"
+		},
+		{
+			"emoji":"⬇️",
+			"entity":"⬇️",
+			"code":":arrow_down:",
+			"description":"Downgrading dependencies.",
+			"name":"arrow-down"
+		},
+		{
+			"emoji":"⬆️",
+			"entity":"⬆️",
+			"code":":arrow_up:",
+			"description":"Upgrading dependencies.",
+			"name":"arrow-up"
+		},
+		{
+			"emoji": "📌",
+			"entity": "&#x1F4CC;",
+			"code": ":pushpin:",
+			"description": "Pinning dependencies to specific versions.",
+			"name": "pushpin"
+		},
+		{
+			"emoji":"👷",
+			"entity":"&#x1f477;",
+			"code":":construction_worker:",
+			"description":"Adding CI build system.",
+			"name":"construction-worker"
+		},
+		{
+			"emoji":"📈",
+			"code":":chart_with_upwards_trend:",
+			"description":"Adding analytics or tracking code.",
+			"name":"chart-with-upwards-trend"
+		},
+		{
+			"emoji":"♻️",
+			"entity":"&#x2672;",
+			"code":":recycle:",
+			"description":"Refactoring code.",
+			"name":"recycle"
+		},
+		{
+			"emoji":"🐳",
+			"entity":"&#x1f433;",
+			"code":":whale:",
+			"description":"Work about Docker.",
+			"name":"whale"
+		},
+		{
+			"emoji":"➕",
+			"entity":"&#10133;",
+			"code":":heavy_plus_sign:",
+			"description":"Adding a dependency.",
+			"name":"heavy-plus-sign"
+		},
+		{
+			"emoji":"➖",
+			"entity":"&#10134;",
+			"code":":heavy_minus_sign:",
+			"description":"Removing a dependency.",
+			"name":"heavy-minus-sign"
+		},
+		{
+			"emoji":"🔧",
+			"entity":"&#x1f527;",
+			"code":":wrench:",
+			"description":"Changing configuration files.",
+			"name":"wrench"
+		},
+		{
+			"emoji": "🌐",
+			"entity": "&#127760;",
+			"code": ":globe_with_meridians:",
+			"description": "Internationalization and localization.",
+			"name": "globe-with-meridians"
+		},
+		{
+			"emoji":"✏️",
+			"entity":"&#59161;",
+			"code":":pencil2:",
+			"description":"Fixing typos.",
+			"name":"pencil"
+		},
+		{
+			"emoji":"💩",
+			"entity":"&#58613;",
+			"code":":poop:",
+			"description":"Writing bad code that needs to be improved.",
+			"name":"poop"
+		},
+		{
+			"emoji":"⏪",
+			"entity":"&#9194;",
+			"code":":rewind:",
+			"description":"Reverting changes.",
+			"name":"rewind"
+		},
+		{
+			"emoji":"🔀",
+			"entity":"&#128256;",
+			"code":":twisted_rightwards_arrows:",
+			"description":"Merging branches.",
+			"name":"twisted-rightwards-arrows"
+		},
+		{
+			"emoji":"📦",
+			"entity":"&#1F4E6;",
+			"code":":package:",
+			"description":"Updating compiled files or packages.",
+			"name":"package"
+		},
+		{
+			"emoji":"👽",
+			"entity":"&#1F47D;",
+			"code":":alien:",
+			"description":"Updating code due to external API changes.",
+			"name":"alien"
+		},
+		{
+			"emoji":"🚚",
+			"entity":"&#1F69A;",
+			"code":":truck:",
+			"description":"Moving or renaming files.",
+			"name":"truck"
+		},
+		{
+			"emoji":"📄",
+			"entity":"&#1F4C4;",
+			"code":":page_facing_up:",
+			"description":"Adding or updating license.",
+			"name":"page-facing-up"
+		},
+		{
+			"emoji":"💥",
+			"entity":"&#x1f4a5;",
+			"code":":boom:",
+			"description":"Introducing breaking changes.",
+			"name":"boom"
+		},
+		{
+			"emoji":"🍱",
+			"entity":"&#1F371",
+			"code":":bento:",
+			"description":"Adding or updating assets.",
+			"name":"bento"
+		},
+		{
+			"emoji":"👌",
+			"entity":"&#x1f44c;",
+			"code":":ok_hand:",
+			"description":"Updating code due to code review changes.",
+			"name":"ok-hand"
+		},
+		{
+			"emoji": "♿️",
+			"entity":"&#9855;",
+			"code": ":wheelchair:",
+			"description":"Improving accessibility.",
+			"name":"wheelchair"
+		},
+		{
+			"emoji": "💡",
+			"entity":"&#128161;",
+			"code": ":bulb:",
+			"description":"Documenting source code.",
+			"name":"bulb"
+		},
+		{
+			"emoji": "🍻",
+			"entity":"&#x1f37b;",
+			"code": ":beers:",
+			"description": "Writing code drunkenly.",
+			"name":"beers"
+		},
+		{
+			"emoji": "💬",
+			"entity":"&#128172;",
+			"code": ":speech_balloon:",
+			"description": "Updating text and literals.",
+			"name":"speech-balloon"
+		},
+		{
+			"emoji": "🗃",
+			"entity":"&#128451;",
+			"code": ":card_file_box:",
+			"description": "Performing database related changes.",
+			"name":"card-file-box"
+		},
+		{
+			"emoji":"🔊",
+			"entity":"&#128266;",
+			"code":":loud_sound:",
+			"description":"Adding logs.",
+			"name":"loud-sound"
+		},
+		{
+			"emoji":"🔇",
+			"entity":"&#128263;",
+			"code":":mute:",
+			"description":"Removing logs.",
+			"name":"mute"
+		},
+		{
+			"emoji": "👥",
+			"entity": "&#128101;",
+			"code": ":busts_in_silhouette:",
+			"description": "Adding contributor(s).",
+			"name": "busts-in-silhouette"
+		},
+		{
+			"emoji": "🚸",
+			"entity": "&#128696;",
+			"code": ":children_crossing:",
+			"description": "Improving user experience / usability.",
+			"name": "children-crossing"
+		},
+		{
+			"emoji": "🏗",
+			"entity": "&#1f3d7;",
+			"code": ":building_construction:",
+			"description": "Making architectural changes.",
+			"name": "building-construction"
+		},
+		{
+			"emoji": "📱",
+			"entity": "&#128241;" ,
+			"code": ":iphone:",
+			"description": "Working on responsive design.",
+			"name": "iphone"
+		},
+		{
+			"emoji": "🤡",
+			"entity": "&#129313;" ,
+			"code": ":clown_face:",
+			"description": "Mocking things.",
+			"name": "clown-face"
+		},
+		{
+			"emoji": "🥚",
+			"entity": "&#129370;",
+			"code": ":egg:",
+			"description": "Adding an easter egg.",
+			"name": "egg"
+		},
+		{
+			"emoji": "🙈",
+			"entity": "&#8bdfe7;" ,
+			"code": ":see_no_evil:",
+			"description": "Adding or updating a .gitignore file",
+			"name": "see-no-evil"
+		},
+		{
+			"emoji": "📸",
+			"entity": "&#128248;" ,
+			"code": ":camera_flash:",
+			"description": "Adding or updating snapshots",
+			"name": "camera-flash"
+		},
+		{
+			"emoji": "⚗",
+			"entity": "&#128248;" ,
+			"code": ":alembic:",
+			"description": "Experimenting new things",
+			"name": "alembic"
+		},
+		{
+			"emoji": "🔍",
+			"entity": "&#128269;" ,
+			"code": ":mag:",
+			"description": "Improving SEO",
+			"name": "mag"
+		},
+		{
+		  "emoji":"☸️",
+		  "entity":"&#9784;",
+		  "code":":wheel_of_dharma:",
+		  "description":"Work about Kubernetes",
+		  "name":"wheel-of-dharma"
+		},
+		{
+		  "emoji": "🏷️",
+		  "entity": "&#127991;",
+		  "code": ":label:",
+		  "description": "Adding or updating types (Flow, TypeScript)",
+		  "name": "label"		
+		}
+	]
+}

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -11,6 +11,7 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"removeComments": true,
+		"resolveJsonModule": true,
 		"sourceMap": true,
 		"strict": true,
 		"target": "es6"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -29,7 +29,8 @@ export function prepareCommitMesage(commitMessage: string) : string {
 	});
 	// autolink urls
 	commitMessage = escapeHtml(commitMessage);
-	commitMessage = autolinker.link(commitMessage);
+	if(getConfig().autoLinkUrlsInCommitMessages())
+		commitMessage = autolinker.link(commitMessage);
 	return commitMessage;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { getConfig } from './config';
 import { encodeDiffDocUri } from './diffDocProvider';
+import { gitmojis } from './gitmojis.json';
 import { GitFileChangeType } from './types';
 
 const FS_REGEX = /\\/g;
@@ -9,6 +10,15 @@ export const UNCOMMITTED = '*';
 
 export function abbrevCommit(commitHash: string) {
 	return commitHash.substring(0, 8);
+}
+
+export function prepareCommitMesage(commitMessage: string) : string {
+	// replace gitmojis
+	gitmojis.forEach(function(gitmoji) {
+		commitMessage = commitMessage.replace(new RegExp(gitmoji.code, 'gim'), gitmoji.emoji);
+	});
+	// autolink urls
+	return commitMessage;
 }
 
 export function getPathFromUri(uri: vscode.Uri) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,22 @@
+import { Autolinker } from 'autolinker';
 import * as vscode from 'vscode';
 import { getConfig } from './config';
 import { encodeDiffDocUri } from './diffDocProvider';
 import { gitmojis } from './gitmojis.json';
 import { GitFileChangeType } from './types';
 
+const htmlEscapes: { [key: string]: string } = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', '\'': '&#x27;' };
+const htmlEscaper = /[&<>"']/g;
+
 const FS_REGEX = /\\/g;
 
+const autolinker = new Autolinker();
+
 export const UNCOMMITTED = '*';
+
+function escapeHtml(str: string) {
+	return str.replace(htmlEscaper, (match) => htmlEscapes[match]);
+}
 
 export function abbrevCommit(commitHash: string) {
 	return commitHash.substring(0, 8);
@@ -18,6 +28,8 @@ export function prepareCommitMesage(commitMessage: string) : string {
 		commitMessage = commitMessage.replace(new RegExp(gitmoji.code, 'gim'), gitmoji.emoji);
 	});
 	// autolink urls
+	commitMessage = escapeHtml(commitMessage);
+	commitMessage = autolinker.link(commitMessage);
 	return commitMessage;
 }
 

--- a/web/main.ts
+++ b/web/main.ts
@@ -409,7 +409,7 @@ class GitGraphView {
 
 		for (let i = 0; i < this.commits.length; i++) {
 			commit = this.commits[i];
-			let refBranches = '', refTags = '', message = escapeHtml(commit.message), date = getCommitDate(commit.date), j, k, refName, remoteName, refActive, refHtml, branchLabels = getBranchLabels(commit.heads, commit.remotes);
+			let refBranches = '', refTags = '', message = commit.message, date = getCommitDate(commit.date), j, k, refName, remoteName, refActive, refHtml, branchLabels = getBranchLabels(commit.heads, commit.remotes);
 
 			for (j = 0; j < branchLabels.heads.length; j++) {
 				refName = escapeHtml(branchLabels.heads[j].name);
@@ -1185,7 +1185,7 @@ class GitGraphView {
 					html += '<b>Committer: </b>' + escapeHtml(commitDetails.committer) + '</span>';
 					if (typeof this.avatars[commitDetails.email] === 'string') html += '<span class="commitDetailsSummaryAvatar"><img src="' + this.avatars[commitDetails.email] + '"></span>';
 					html += '</span></span><br><br>';
-					html += escapeHtml(commitDetails.body).replace(/\n/g, '<br>');
+					html += commitDetails.body.replace(/\n/g, '<br>');
 				} else {
 					html += 'Displaying all uncommitted changes.';
 				}


### PR DESCRIPTION
Issue Number / Link: #104 

Summary of the issue: Add gitmoji support and autolinking to commit messages

Description outlining how this pull request resolves the issue:

I took the gitmoji.json unmodified from here: https://github.com/carloscuesta/gitmoji/blob/master/src/data/gitmojis.json This should make updating in the future as easy as dropping in the new gitmoji.json. To pull the list from Github at application start would probably be a bit overkill.

Autolinking to me seems to be a reasonably complex problem to warrant the usage of a third-party package like https://www.npmjs.com/package/autolinker There is probably a more elegant way to initialize the class than what I did in the [utils.ts on line 13](https://github.com/sebastianlay/vscode-git-graph/blob/97c18e3d3571c1ec609afeafce4bd1d29861c7af/src/utils.ts#L13). I just don't know enough typescript yet.
Also the utils.ts does seem to have the line break issue again. Looks like there always has to be _that_ file...

Both the gitmojis and the autolinker are under MIT license so that should be fine as far as I know.