### PR TITLE
Fixes #192 Diff failing for some oddly named file

### DIFF
--- a/src/diffDocProvider.ts
+++ b/src/diffDocProvider.ts
@@ -92,7 +92,7 @@ export function encodeDiffDocUri(repo: string, filePath: string, commit: string,
 		let extIndex = data.filePath.indexOf('.', data.filePath.lastIndexOf('/') + 1);
 		extension = extIndex > -1 ? data.filePath.substring(extIndex) : '';
 	}
-	return vscode.Uri.parse(DiffDocProvider.scheme + ':file' + extension + '?' + Buffer.from(JSON.stringify(data)).toString('base64'));
+	return vscode.Uri.parse(DiffDocProvider.scheme + ':file' + extension).with({query:Buffer.from(JSON.stringify(data)).toString('base64')});
 }
 
 export function decodeDiffDocUri(uri: vscode.Uri): DiffDocUriData {


### PR DESCRIPTION
Issue Link: #192 

Summary of the issue: Diff sometime fails if file name contains # 

Description outlining how this pull request resolves the issue:
These names confuse vscode.Uri.parse, which generates an empty string.
By replacing the concatenation of the query string and replacing it with a 
.with({query:...}) 
it will always return the right query string

PS: I guess I should have created this directly for such a trivial one but here we are...