### PR TITLE
Add an ellipsis at the end of a subject if body isn't empty

### DIFF
--- a/src/dataSource.ts
+++ b/src/dataSource.ts
@@ -49,7 +49,7 @@ export class DataSource {
 		const dateType = config.dateType === DateType.Author ? '%at' : '%ct';
 		const useMailmap = config.useMailmap;
 		this.gitFormatCommitDetails = ['%H', '%P', useMailmap ? '%aN' : '%an', useMailmap ? '%aE' : '%ae', dateType, useMailmap ? '%cN' : '%cn'].join(GIT_LOG_SEPARATOR) + '%n%B';
-		this.gitFormatLog = ['%H', '%P', useMailmap ? '%aN' : '%an', useMailmap ? '%aE' : '%ae', dateType, '%s'].join(GIT_LOG_SEPARATOR);
+		this.gitFormatLog = ['%H', '%P', useMailmap ? '%aN' : '%an', useMailmap ? '%aE' : '%ae', dateType, '%s', '%b'].join(GIT_LOG_SEPARATOR);
 		this.gitFormatStash = ['%H', '%P', '%gD', useMailmap ? '%aN' : '%an', useMailmap ? '%aE' : '%ae', dateType, '%s'].join(GIT_LOG_SEPARATOR);
 	}
 
@@ -769,8 +769,19 @@ export class DataSource {
 			let commits: GitCommitRecord[] = [];
 			for (let i = 0; i < lines.length - 1; i++) {
 				let line = lines[i].split(GIT_LOG_SEPARATOR);
-				if (line.length !== 6) break;
-				commits.push({ hash: line[0], parents: line[1] !== '' ? line[1].split(' ') : [], author: line[2], email: line[3], date: parseInt(line[4]), message: line[5] });
+				if (line.length < 7) {
+					// The length can be less that 7 because the current line is a part of
+					// multiline body. Ignore it and process the next lines
+					continue;
+				}
+				commits.push({
+					hash: line[0],
+					parents: line[1] !== '' ? line[1].split(' ') : [],
+					author: line[2],
+					email: line[3],
+					date: parseInt(line[4]),
+					message: line[5] + (line[6] !== '' ? '…' : ''), // add '…' if body isn't empty
+				});
 			}
 			return commits;
 		});


### PR DESCRIPTION
**Summary of the issue:** add an ellipsis (`…`) at the end of a subject if body isn't empty

**Details:**

| Before | After |
| ------ | ------|
| ![image](https://user-images.githubusercontent.com/30220965/71780941-ce134700-2fd9-11ea-883c-6034bf44c3e5.png) | ![image](https://user-images.githubusercontent.com/30220965/71780930-b1770f00-2fd9-11ea-93be-cde06312254a.png) |

<details>
<summary>'git log' output for this repo</summary>

![image](https://user-images.githubusercontent.com/30220965/71780949-eedb9c80-2fd9-11ea-8460-cb695ffaafe4.png)
</details>

I had to replace `break` statement with `continue` ([src/dataSource.ts:775](https://github.com/mhutchie/vscode-git-graph/compare/master...ShoshinNikita:master#diff-0ad29a853fa0151fd678d46d52731f7dR775)) because commits with multiline body broke the processing. I couldn't find out any way to replace `\n` chars in the body with `git log` command. So, I just ignore such lines. I would be glad to hear your thoughts about this solution

![image](https://user-images.githubusercontent.com/30220965/71780994-9789fc00-2fda-11ea-8af1-1d9ee89be3ef.png)


