### PR TITLE
Add Copy Commit Message to Clipboard context menu option

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,6 +202,10 @@
 								"copyHash": {
 									"type": "boolean",
 									"title": "Copy Commit Hash to Clipboard"
+								},
+								"copyMessage": {
+									"type": "boolean",
+									"title": "Copy Commit Message to Clipboard"
 								}
 							}
 						},

--- a/src/config.ts
+++ b/src/config.ts
@@ -72,7 +72,7 @@ class Config {
 		let userConfig = this.config.get('contextMenuActionsVisibility', {});
 		let config = {
 			branch: { checkout: true, rename: true, delete: true, merge: true, rebase: true, push: true, copyName: true },
-			commit: { addTag: true, createBranch: true, checkout: true, cherrypick: true, revert: true, drop: true, merge: true, rebase: true, reset: true, copyHash: true },
+			commit: { addTag: true, createBranch: true, checkout: true, cherrypick: true, revert: true, drop: true, merge: true, rebase: true, reset: true, copyHash: true, copyMessage: true },
 			remoteBranch: { checkout: true, delete: true, fetch: true, pull: true, copyName: true },
 			stash: { apply: true, createBranch: true, pop: true, drop: true, copyName: true, copyHash: true },
 			tag: { viewDetails: true, delete: true, push: true, copyName: true },

--- a/src/types.ts
+++ b/src/types.ts
@@ -229,6 +229,7 @@ export interface ContextMenuActionsVisibility {
 		readonly rebase: boolean;
 		readonly reset: boolean;
 		readonly copyHash: boolean;
+		readonly copyMessage: boolean;
 	};
 	readonly remoteBranch: {
 		readonly checkout: boolean;

--- a/web/main.ts
+++ b/web/main.ts
@@ -906,6 +906,7 @@ class GitGraphView {
 
 	private getCommitContextMenuActions(target: DialogTarget & CommitTarget): ContextMenuActions {
 		const hash = target.hash, visibility = this.config.contextMenuActionsVisibility.commit;
+		const commit = this.commits[this.commitLookup[hash]];
 		return [[
 			{
 				title: 'Add Tag' + ELLIPSIS,
@@ -1073,6 +1074,13 @@ class GitGraphView {
 				visible: visibility.copyHash,
 				onClick: () => {
 					sendMessage({ command: 'copyToClipboard', type: 'Commit Hash', data: hash });
+				}
+			},
+			{
+				title: 'Copy Commit Message to Clipboard',
+				visible: visibility.copyMessage,
+				onClick: () => {
+					sendMessage({ command: 'copyToClipboard', type: 'Commit Message', data: commit.message });
 				}
 			}
 		]];


### PR DESCRIPTION
Add Copy Commit Message to Clipboard context menu option

Issue Number / Link: https://github.com/mhutchie/vscode-git-graph/issues/267

Summary of the issue:
>Currently there is an available feature in the commit context menu to "Copy Commit Hash to Clipboard". I would like to add functionality to also copy commit message to the context menu.

Description outlining how this pull request resolves the issue:
Code adds feature