### PR TITLE
Avoid submitting dialogs when IME emits "Enter".

### DIFF
--- a/web/main.ts
+++ b/web/main.ts
@@ -1665,7 +1665,7 @@ class GitGraphView {
 			if (dialog.isOpen()) {
 				if (e.key === 'Escape') {
 					dialog.close();
-				} else if (e.key === 'Enter') {
+				} else if (e.keyCode === 13 /* Detects "Enter" (13) except for IME confirmation (229) */) {
 					dialog.submit();
 				}
 			} else if (contextMenu.isOpen()) {


### PR DESCRIPTION
Thank you for developing a very useful extension! I would like to give improvement for CJK users.

Summary of the issue: Avoid submitting dialogs when IME emits "Enter".

Description outlining how this pull request resolves the issue:
For CJK users, the Enter key is emitted not only when we complete the input but also to select the right Kanji for words. So capturing all Enter key inputs prevents us from inputting multiple words.
I used `event.keyCode` instead of `event.key` to make a difference between the selection and the completion.

Issue movie (current behavior):
[![Alt text](https://img.youtube.com/vi/vZ1GuqQ4bsU/0.jpg)](https://youtu.be/vZ1GuqQ4bsU)

This PR version:
[![Alt text](https://img.youtube.com/vi/kokc2BXUDME/0.jpg)](https://youtu.be/kokc2BXUDME)