### PR TITLE
Fix right-click menu being hidden when running in a browser

### DIFF
--- a/web/main.ts
+++ b/web/main.ts
@@ -1583,6 +1583,7 @@ class GitGraphView {
 		});
 
 		colHeadersElem.addEventListener('contextmenu', (e: MouseEvent) => {
+			e.preventDefault();
 			e.stopPropagation();
 			const toggleColumnState = (col: number, defaultWidth: number) => {
 				columnWidths[col] = columnWidths[col] !== COLUMN_HIDDEN ? COLUMN_HIDDEN : columnWidths[0] === COLUMN_AUTO ? COLUMN_AUTO : defaultWidth - COLUMN_LEFT_RIGHT_PADDING;
@@ -1915,6 +1916,7 @@ class GitGraphView {
 
 			if ((eventElem = <HTMLElement>eventTarget.closest('.gitRef')) !== null) {
 				// .gitRef was right clicked
+				e.preventDefault();
 				e.stopPropagation();
 				const commitElem = <HTMLElement>eventElem.closest('.commit')!;
 				const commit = this.getCommitOfElem(commitElem);
@@ -1952,6 +1954,7 @@ class GitGraphView {
 
 			} else if ((eventElem = <HTMLElement>eventTarget.closest('.commit')) !== null) {
 				// .commit was right clicked
+				e.preventDefault();
 				e.stopPropagation();
 				const commit = this.getCommitOfElem(eventElem);
 				if (commit === null) return;


### PR DESCRIPTION
If running this plugin in a browser (e.g. using theia or gitpod), when you right-click on a commit, git graph's right click menu appears but the browser right click menu appears over the top of it. This PR fixes that by preventing the browser right click menu appearing, allowing you to use git graph's menu as intended.

As far as I can see this change has no negative impact when running natively in VS Code.