### PR TITLE
added option to filter branch labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -360,6 +360,10 @@
 					"default": [],
 					"description": "An array of Custom Branch Glob Patterns to be shown in the 'Branches' dropdown. Example: [{\"name\": \"Feature Requests\", \"glob\": \"heads/feature/*\"}]"
 				},
+				"git-graph.branchLabelHideRegex": {
+					"type": "string",
+					"description": "Regex formatted string. If it matches branch name or remote name label will be hidden"
+				},
 				"git-graph.customEmojiShortcodeMappings": {
 					"type": "array",
 					"items": {

--- a/package.json
+++ b/package.json
@@ -360,9 +360,10 @@
 					"default": [],
 					"description": "An array of Custom Branch Glob Patterns to be shown in the 'Branches' dropdown. Example: [{\"name\": \"Feature Requests\", \"glob\": \"heads/feature/*\"}]"
 				},
-				"git-graph.branchLabelHideRegex": {
-					"type": "string",
-					"description": "Regex formatted string. If it matches branch name or remote name label will be hidden"
+				"git-graph.branchLabelHideOriginHead": {
+					"type": "boolean",
+					"default": true,
+					"description": "Visibility of the origin/HEAD label"
 				},
 				"git-graph.customEmojiShortcodeMappings": {
 					"type": "array",

--- a/src/config.ts
+++ b/src/config.ts
@@ -100,6 +100,10 @@ class Config {
 		return outPatterns;
 	}
 
+	get branchLabelHideRegex(): string {
+		return this.config.get('branchLabelHideRegex', <string>'');
+	}
+
 	/**
 	 * Get the value of the `git-graph.customEmojiShortcodeMappings` Extension Setting.
 	 */

--- a/src/config.ts
+++ b/src/config.ts
@@ -101,7 +101,7 @@ class Config {
 	}
 
 	get branchLabelHideRegex(): string {
-		return this.config.get('branchLabelHideRegex', <string>'');
+		return this.config.get('branchLabelHideOriginHead', <boolean>true) ? '' : 'origin/HEAD';
 	}
 
 	/**

--- a/src/gitGraphView.ts
+++ b/src/gitGraphView.ts
@@ -585,6 +585,7 @@ export class GitGraphView extends Disposable {
 				commitOrdering: config.commitOrder,
 				contextMenuActionsVisibility: config.contextMenuActionsVisibility,
 				customBranchGlobPatterns: config.customBranchGlobPatterns,
+				branchLabelHideRegex: config.branchLabelHideRegex,
 				customEmojiShortcodeMappings: config.customEmojiShortcodeMappings,
 				customPullRequestProviders: config.customPullRequestProviders,
 				dateFormat: config.dateFormat,

--- a/src/types.ts
+++ b/src/types.ts
@@ -213,6 +213,7 @@ export interface GitGraphViewConfig {
 	readonly commitOrdering: CommitOrdering;
 	readonly contextMenuActionsVisibility: ContextMenuActionsVisibility;
 	readonly customBranchGlobPatterns: ReadonlyArray<CustomBranchGlobPattern>;
+	readonly branchLabelHideRegex: string;
 	readonly customEmojiShortcodeMappings: ReadonlyArray<CustomEmojiShortcodeMapping>;
 	readonly customPullRequestProviders: ReadonlyArray<CustomPullRequestProvider>;
 	readonly dateFormat: DateFormat;

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -482,6 +482,33 @@ describe('Config', () => {
 		});
 	});
 
+	describe('branchLabelHideRegex', () => {
+		it('Should return a string based on the configuration value', () => {
+			// Setup
+			workspaceConfiguration.get.mockReturnValueOnce('master');
+
+			// Run
+			const value = config.branchLabelHideRegex;
+
+			// Assert
+			expect(workspaceConfiguration.get).toBeCalledWith('branchLabelHideRegex', '');
+			expect(value).toHaveLength(6);
+			expect(value).toStrictEqual('master');
+		});
+
+		it('Should return the default value "" when the configuration value is not set', () => {
+			// Setup
+			workspaceConfiguration.get.mockImplementationOnce((_, defaultValue) => defaultValue);
+
+			// Run
+			const value = config.branchLabelHideRegex;
+
+			// Assert
+			expect(workspaceConfiguration.get).toBeCalledWith('branchLabelHideRegex', '');
+			expect(value).toHaveLength(0);
+		});
+	});
+
 	describe('customEmojiShortcodeMappings', () => {
 		it('Should return a filtered array of emoji shortcode mappings based on the configuration value', () => {
 			// Setup

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -482,18 +482,57 @@ describe('Config', () => {
 		});
 	});
 
-	describe('branchLabelHideRegex', () => {
-		it('Should return a string based on the configuration value', () => {
+	describe('branchLabelHideOriginHead', () => {
+		it('Should return "" when the configuration value is TRUE', () => {
 			// Setup
-			workspaceConfiguration.get.mockReturnValueOnce('master');
+			workspaceConfiguration.get.mockReturnValueOnce(true);
 
 			// Run
 			const value = config.branchLabelHideRegex;
 
 			// Assert
-			expect(workspaceConfiguration.get).toBeCalledWith('branchLabelHideRegex', '');
-			expect(value).toHaveLength(6);
-			expect(value).toStrictEqual('master');
+			expect(workspaceConfiguration.get).toBeCalledWith('branchLabelHideOriginHead', true);
+			expect(value).toHaveLength(0);
+			expect(value).toStrictEqual('');
+		});
+
+		it('Should return "origin/HEAD" when the configuration value is FALSE', () => {
+			// Setup
+			workspaceConfiguration.get.mockReturnValueOnce(false);
+
+			// Run
+			const value = config.branchLabelHideRegex;
+
+			// Assert
+			expect(workspaceConfiguration.get).toBeCalledWith('branchLabelHideOriginHead', true);
+			expect(value).toHaveLength(11);
+			expect(value).toStrictEqual('origin/HEAD');
+		});
+
+		it('Should return "" when the configuration value is truthy', () => {
+			// Setup
+			workspaceConfiguration.get.mockReturnValueOnce(5);
+
+			// Run
+			const value = config.branchLabelHideRegex;
+
+			// Assert
+			expect(workspaceConfiguration.get).toBeCalledWith('branchLabelHideOriginHead', true);
+			expect(value).toHaveLength(0);
+			expect(value).toStrictEqual('');
+		});
+
+		it('Should return "origin/HEAD" when the configuration value is falsy', () => {
+			// Setup
+			workspaceConfiguration.get.mockReturnValueOnce(0);
+
+			// Run
+			const value = config.branchLabelHideRegex;
+
+			// Assert
+			expect(workspaceConfiguration.get).toBeCalledWith('branchLabelHideOriginHead', true);
+			expect(value).toHaveLength(11);
+			expect(value).toStrictEqual('origin/HEAD');
 		});
 
 		it('Should return the default value "" when the configuration value is not set', () => {
@@ -504,8 +543,9 @@ describe('Config', () => {
 			const value = config.branchLabelHideRegex;
 
 			// Assert
-			expect(workspaceConfiguration.get).toBeCalledWith('branchLabelHideRegex', '');
+			expect(workspaceConfiguration.get).toBeCalledWith('branchLabelHideOriginHead', true);
 			expect(value).toHaveLength(0);
+			expect(value).toStrictEqual('');
 		});
 	});
 

--- a/web/main.ts
+++ b/web/main.ts
@@ -746,7 +746,10 @@ class GitGraphView {
 			let commit = this.commits[i];
 			let message = '<span class="text">' + textFormatter.format(commit.message) + '</span>';
 			let date = formatShortDate(commit.date);
-			let branchLabels = getBranchLabels(commit.heads, commit.remotes);
+			let branchLabels = getBranchLabels(
+				this.config.branchLabelHideRegex ? commit.heads.filter((name: string) => !name.match(this.config.branchLabelHideRegex)) : commit.heads,
+				this.config.branchLabelHideRegex ? commit.remotes.filter((remote: { name: string; }) => !remote.name.match(this.config.branchLabelHideRegex)) : commit.remotes
+			);
 			let refBranches = '', refTags = '', j, k, refName, remoteName, refActive, refHtml, branchCheckedOutAtCommit: string | null = null;
 
 			for (j = 0; j < branchLabels.heads.length; j++) {


### PR DESCRIPTION
Issue Number / Link: [#407 ](https://github.com/mhutchie/vscode-git-graph/issues/407)

Summary of the issue:
Feature to filter branch labels that show in graph to make it more clear

Description outlining how this pull request resolves the issue:
Probably code could be better but i hope it will be helpful for you