### PR TITLE
improved performance of most for loops

### DIFF
--- a/.vscode/package-web.js
+++ b/.vscode/package-web.js
@@ -73,7 +73,7 @@ packageCssFiles.forEach((fileName) => {
 		cssFileContents += contents + '\r\n';
 	} else {
 		let lines = contents.split(/\r\n|\r|\n/g);
-		for (let j = 0; j < lines.length; j++) {
+		for (let j = 0, length = lines.length; j < length; j++) {
 			if (lines[j].startsWith('\t')) lines[j] = lines[j].substring(1);
 		}
 		let j = 0;

--- a/src/config.ts
+++ b/src/config.ts
@@ -97,7 +97,7 @@ class Config {
 	get customBranchGlobPatterns(): CustomBranchGlobPattern[] {
 		let inPatterns = this.config.get('customBranchGlobPatterns', <any[]>[]);
 		let outPatterns: CustomBranchGlobPattern[] = [];
-		for (let i = 0; i < inPatterns.length; i++) {
+		for (let i = 0, length = inPatterns.length; i < length; i++) {
 			if (typeof inPatterns[i].name === 'string' && typeof inPatterns[i].glob === 'string') {
 				outPatterns.push({ name: inPatterns[i].name, glob: '--glob=' + inPatterns[i].glob });
 			}
@@ -111,7 +111,7 @@ class Config {
 	get customEmojiShortcodeMappings(): CustomEmojiShortcodeMapping[] {
 		let inMappings = this.config.get('customEmojiShortcodeMappings', <any[]>[]);
 		let outMappings: CustomEmojiShortcodeMapping[] = [];
-		for (let i = 0; i < inMappings.length; i++) {
+		for (let i = 0, length = inMappings.length; i < length; i++) {
 			if (typeof inMappings[i].shortcode === 'string' && typeof inMappings[i].emoji === 'string') {
 				outMappings.push({ shortcode: inMappings[i].shortcode, emoji: inMappings[i].emoji });
 			}
@@ -609,7 +609,7 @@ function mergeConfigObjects(base: { [key: string]: any }, user: { [key: string]:
 	if (typeof base !== typeof user) return;
 
 	let keys = Object.keys(base);
-	for (let i = 0; i < keys.length; i++) {
+	for (let i = 0, length = keys.length; i < length; i++) {
 		if (typeof base[keys[i]] === 'object') {
 			if (typeof user[keys[i]] === 'object') {
 				mergeConfigObjects(base[keys[i]], user[keys[i]]);

--- a/src/dataSource.ts
+++ b/src/dataSource.ts
@@ -504,7 +504,7 @@ export class DataSource extends Disposable {
 					let lines = data.split(EOL_REGEX), inSubmoduleSection = false, match;
 					const section = /^\s*\[.*\]\s*$/, submodule = /^\s*\[submodule "([^"]+)"\]\s*$/, pathProp = /^\s*path\s+=\s+(.*)$/;
 
-					for (let i = 0; i < lines.length; i++) {
+					for (let i = 0, length = lines.length; i < length; i++) {
 						if (lines[i].match(section) !== null) {
 							inSubmoduleSection = lines[i].match(submodule) !== null;
 							continue;
@@ -762,7 +762,7 @@ export class DataSource extends Disposable {
 		}
 
 		const results: ErrorInfo[] = [];
-		for (let i = 0; i < remotes.length; i++) {
+		for (let i = 0, length = remotes.length; i < length; i++) {
 			const result = await this.pushBranch(repo, branchName, remotes[i], setUpstream, mode);
 			results.push(result);
 			if (result !== null) break;
@@ -783,7 +783,7 @@ export class DataSource extends Disposable {
 		}
 
 		const results: ErrorInfo[] = [];
-		for (let i = 0; i < remotes.length; i++) {
+		for (let i = 0, length = remotes.length; i < length; i++) {
 			const result = await this.pushTag(repo, tagName, remotes[i]);
 			results.push(result);
 			if (result !== null) break;
@@ -1266,7 +1266,7 @@ export class DataSource extends Disposable {
 		return this.spawnGit(args, repo, (stdout) => {
 			let branchData: GitBranchData = { branches: [], head: null, error: null };
 			let lines = stdout.split(EOL_REGEX);
-			for (let i = 0; i < lines.length - 1; i++) {
+			for (let i = 0, length = lines.length - 1; i < length; i++) {
 				let name = lines[i].substring(2).split(' -> ')[0];
 				if (INVALID_BRANCH_REGEXP.test(name) || hideRemotePatterns.some((pattern) => name.startsWith(pattern)) || (!showRemoteHeads && REMOTE_HEAD_BRANCH_REGEXP.test(name))) {
 					continue;
@@ -1425,7 +1425,7 @@ export class DataSource extends Disposable {
 		let args = ['log', '--max-count=' + num, '--format=' + this.gitFormatLog, '--' + order + '-order'];
 		if (onlyFollowFirstParent) args.push('--first-parent');
 		if (branches !== null) {
-			for (let i = 0; i < branches.length; i++) {
+			for (let i = 0, length = branches.length; i < length; i++) {
 				args.push(branches[i]);
 			}
 		} else {
@@ -1454,7 +1454,7 @@ export class DataSource extends Disposable {
 		return this.spawnGit(args, repo, (stdout) => {
 			let lines = stdout.split(EOL_REGEX);
 			let commits: GitCommitRecord[] = [];
-			for (let i = 0; i < lines.length - 1; i++) {
+			for (let i = 0, length = lines.length - 1; i < length; i++) {
 				let line = lines[i].split(GIT_LOG_SEPARATOR);
 				if (line.length !== 6) break;
 				commits.push({ hash: line[0], parents: line[1] !== '' ? line[1].split(' ') : [], author: line[2], email: line[3], date: parseInt(line[4]), message: line[5] });
@@ -1481,7 +1481,7 @@ export class DataSource extends Disposable {
 		return this.spawnGit(args, repo, (stdout) => {
 			let refData: GitRefData = { head: null, heads: [], tags: [], remotes: [] };
 			let lines = stdout.split(EOL_REGEX);
-			for (let i = 0; i < lines.length - 1; i++) {
+			for (let i = 0, length = lines.length - 1; i < length; i++) {
 				let line = lines[i].split(' ');
 				if (line.length < 2) continue;
 
@@ -1514,7 +1514,7 @@ export class DataSource extends Disposable {
 		return this.spawnGit(['reflog', '--format=' + this.gitFormatStash, 'refs/stash', '--'], repo, (stdout) => {
 			let lines = stdout.split(EOL_REGEX);
 			let stashes: GitStash[] = [];
-			for (let i = 0; i < lines.length - 1; i++) {
+			for (let i = 0, length = lines.length - 1; i < length; i++) {
 				let line = lines[i].split(GIT_LOG_SEPARATOR);
 				if (line.length !== 7 || line[1] === '') continue;
 				let parentHashes = line[1].split(' ');

--- a/src/extensionState.ts
+++ b/src/extensionState.ts
@@ -301,7 +301,7 @@ export class ExtensionState extends Disposable {
 		this.updateGlobalState(AVATAR_CACHE, {});
 		fs.readdir(this.globalStoragePath + AVATAR_STORAGE_FOLDER, (err, files) => {
 			if (err) return;
-			for (let i = 0; i < files.length; i++) {
+			for (let i = 0, length = files.length; i < length; i++) {
 				fs.unlink(this.globalStoragePath + AVATAR_STORAGE_FOLDER + '/' + files[i], () => { });
 			}
 		});

--- a/src/gitGraphView.ts
+++ b/src/gitGraphView.ts
@@ -295,7 +295,7 @@ export class GitGraphView extends Disposable {
 			case 'deleteBranch':
 				errorInfos = [await this.dataSource.deleteBranch(msg.repo, msg.branchName, msg.forceDelete)];
 				if (errorInfos[0] === null) {
-					for (let i = 0; i < msg.deleteOnRemotes.length; i++) {
+					for (let i = 0, length = msg.deleteOnRemotes.length; i < length; i++) {
 						errorInfos.push(await this.dataSource.deleteRemoteBranch(msg.repo, msg.branchName, msg.deleteOnRemotes[i]));
 					}
 				}
@@ -655,7 +655,7 @@ export class GitGraphView extends Disposable {
 		const workspaceState = this.extensionState.getWorkspaceViewState();
 
 		let body, numRepos = Object.keys(initialState.repos).length, colorVars = '', colorParams = '';
-		for (let i = 0; i < initialState.config.graph.colours.length; i++) {
+		for (let i = 0, length = initialState.config.graph.colours.length; i < length; i++) {
 			colorVars += '--git-graph-color' + i + ':' + initialState.config.graph.colours[i] + '; ';
 			colorParams += '[data-color="' + i + '"]{--git-graph-color:var(--git-graph-color' + i + ');} ';
 		}

--- a/src/life-cycle/utils.ts
+++ b/src/life-cycle/utils.ts
@@ -130,7 +130,7 @@ export function saveLifeCycleStateInDirectory(directory: string, state: LifeCycl
  * @returns TRUE => Queue was successfully sent & the API is still available, FALSE => The API is no longer available.
  */
 export async function sendQueue(queue: LifeCycleEvent[]) {
-	for (let i = 0; i < queue.length; i++) {
+	for (let i = 0, length = queue.length; i < length; i++) {
 		if (!await sendEvent(queue[i])) return false;
 	}
 	return true;

--- a/src/repoManager.ts
+++ b/src/repoManager.ts
@@ -70,14 +70,14 @@ export class RepoManager extends Disposable {
 			vscode.workspace.onDidChangeWorkspaceFolders(async (e) => {
 				let changes = false, path;
 				if (e.added.length > 0) {
-					for (let i = 0; i < e.added.length; i++) {
+					for (let i = 0, length = e.added.length; i < length; i++) {
 						path = getPathFromUri(e.added[i].uri);
 						if (await this.searchDirectoryForRepos(path, this.maxDepthOfRepoSearch)) changes = true;
 						this.startWatchingFolder(path);
 					}
 				}
 				if (e.removed.length > 0) {
-					for (let i = 0; i < e.removed.length; i++) {
+					for (let i = 0, length = e.removed.length; i < length; i++) {
 						path = getPathFromUri(e.removed[i].uri);
 						if (this.removeReposWithinFolder(path)) changes = true;
 						this.stopWatchingFolder(path);
@@ -111,7 +111,7 @@ export class RepoManager extends Disposable {
 			// Stop watching folders when disposed
 			toDisposable(() => {
 				const folders = Object.keys(this.folderWatchers);
-				for (let i = 0; i < folders.length; i++) {
+				for (let i = 0, length = folders.length; i < length; i++) {
 					this.stopWatchingFolder(folders[i]);
 				}
 			})
@@ -156,13 +156,13 @@ export class RepoManager extends Disposable {
 	private removeReposNotInWorkspace() {
 		let rootsExact = [], rootsFolder = [], workspaceFolders = vscode.workspace.workspaceFolders, repoPaths = Object.keys(this.repos), path;
 		if (typeof workspaceFolders !== 'undefined') {
-			for (let i = 0; i < workspaceFolders.length; i++) {
+			for (let i = 0, length = workspaceFolders.length; i < length; i++) {
 				path = getPathFromUri(workspaceFolders[i].uri);
 				rootsExact.push(path);
 				rootsFolder.push(pathWithTrailingSlash(path));
 			}
 		}
-		for (let i = 0; i < repoPaths.length; i++) {
+		for (let i = 0, length = repoPaths.length; i < length; i++) {
 			let repoPathFolder = pathWithTrailingSlash(repoPaths[i]);
 			if (rootsExact.indexOf(repoPaths[i]) === -1 && !rootsFolder.find(root => repoPaths[i].startsWith(root)) && !rootsExact.find(root => root.startsWith(repoPathFolder))) {
 				this.removeRepo(repoPaths[i]);
@@ -220,7 +220,7 @@ export class RepoManager extends Disposable {
 	 */
 	public getRepos() {
 		let repoPaths = Object.keys(this.repos).sort((a, b) => a.localeCompare(b)), repos: GitRepoSet = {};
-		for (let i = 0; i < repoPaths.length; i++) {
+		for (let i = 0, length = repoPaths.length; i < length; i++) {
 			repos[repoPaths[i]] = this.repos[repoPaths[i]];
 		}
 		return repos;
@@ -241,7 +241,7 @@ export class RepoManager extends Disposable {
 	 */
 	public getRepoContainingFile(path: string) {
 		let repoPaths = Object.keys(this.repos), repo = null;
-		for (let i = 0; i < repoPaths.length; i++) {
+		for (let i = 0, length = repoPaths.length; i < length; i++) {
 			if (path.startsWith(pathWithTrailingSlash(repoPaths[i])) && (repo === null || repo.length < repoPaths[i].length)) repo = repoPaths[i];
 		}
 		return repo;
@@ -254,7 +254,7 @@ export class RepoManager extends Disposable {
 	 */
 	private getReposInFolder(path: string) {
 		let pathFolder = pathWithTrailingSlash(path), repoPaths = Object.keys(this.repos), reposInFolder: string[] = [];
-		for (let i = 0; i < repoPaths.length; i++) {
+		for (let i = 0, length = repoPaths.length; i < length; i++) {
 			if (repoPaths[i] === path || repoPaths[i].startsWith(pathFolder)) reposInFolder.push(repoPaths[i]);
 		}
 		return reposInFolder;
@@ -274,7 +274,7 @@ export class RepoManager extends Disposable {
 		// Check to see if a known repository contains a symlink that resolves the repo
 		let canonicalRepo = await realpath(repo);
 		let repoPaths = Object.keys(this.repos);
-		for (let i = 0; i < repoPaths.length; i++) {
+		for (let i = 0, length = repoPaths.length; i < length; i++) {
 			if (canonicalRepo === (await realpath(repoPaths[i]))) {
 				return repoPaths[i];
 			}
@@ -328,7 +328,7 @@ export class RepoManager extends Disposable {
 	 */
 	private removeReposWithinFolder(path: string) {
 		let reposInFolder = this.getReposInFolder(path);
-		for (let i = 0; i < reposInFolder.length; i++) {
+		for (let i = 0, length = reposInFolder.length; i < length; i++) {
 			this.removeRepo(reposInFolder[i]);
 		}
 		return reposInFolder.length > 0;
@@ -341,7 +341,7 @@ export class RepoManager extends Disposable {
 	 */
 	private isDirectoryWithinRepos(path: string) {
 		let repoPaths = Object.keys(this.repos);
-		for (let i = 0; i < repoPaths.length; i++) {
+		for (let i = 0, length = repoPaths.length; i < length; i++) {
 			if (path === repoPaths[i] || path.startsWith(pathWithTrailingSlash(repoPaths[i]))) return true;
 		}
 		return false;
@@ -367,7 +367,7 @@ export class RepoManager extends Disposable {
 		return new Promise<boolean>(resolve => {
 			let repoPaths = Object.keys(this.repos), changes = false;
 			evalPromises(repoPaths, 3, path => this.dataSource.repoRoot(path)).then(results => {
-				for (let i = 0; i < repoPaths.length; i++) {
+				for (let i = 0, length = repoPaths.length; i < length; i++) {
 					if (results[i] === null) {
 						this.removeRepo(repoPaths[i]);
 						changes = true;
@@ -417,7 +417,7 @@ export class RepoManager extends Disposable {
 		this.logger.log('Searching workspace for new repos ...');
 		let rootFolders = vscode.workspace.workspaceFolders, changes = false;
 		if (typeof rootFolders !== 'undefined') {
-			for (let i = 0; i < rootFolders.length; i++) {
+			for (let i = 0, length = rootFolders.length; i < length; i++) {
 				if (await this.searchDirectoryForRepos(getPathFromUri(rootFolders[i].uri), this.maxDepthOfRepoSearch)) changes = true;
 			}
 		}
@@ -448,7 +448,7 @@ export class RepoManager extends Disposable {
 							resolve(false);
 						} else {
 							let dirs = [];
-							for (let i = 0; i < dirContents.length; i++) {
+							for (let i = 0, length = dirContents.length; i < length; i++) {
 								if (dirContents[i] !== '.git' && await isDirectory(directory + '/' + dirContents[i])) {
 									dirs.push(directory + '/' + dirContents[i]);
 								}
@@ -468,7 +468,7 @@ export class RepoManager extends Disposable {
 	 */
 	private async checkReposForNewSubmodules() {
 		let repoPaths = Object.keys(this.repos), changes = false;
-		for (let i = 0; i < repoPaths.length; i++) {
+		for (let i = 0, length = repoPaths.length; i < length; i++) {
 			if (await this.searchRepoForSubmodules(repoPaths[i])) changes = true;
 		}
 		if (changes) this.sendRepos();
@@ -481,7 +481,7 @@ export class RepoManager extends Disposable {
 	 */
 	private async searchRepoForSubmodules(repo: string) {
 		let submodules = await this.dataSource.getSubmodules(repo), changes = false;
-		for (let i = 0; i < submodules.length; i++) {
+		for (let i = 0, length = submodules.length; i < length; i++) {
 			if (!this.isKnownRepo(submodules[i])) {
 				if (await this.addRepo(submodules[i])) changes = true;
 			}
@@ -498,7 +498,7 @@ export class RepoManager extends Disposable {
 	private startWatchingFolders() {
 		let rootFolders = vscode.workspace.workspaceFolders;
 		if (typeof rootFolders !== 'undefined') {
-			for (let i = 0; i < rootFolders.length; i++) {
+			for (let i = 0, length = rootFolders.length; i < length; i++) {
 				this.startWatchingFolder(getPathFromUri(rootFolders[i].uri));
 			}
 		}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,7 +51,7 @@ export function pathWithTrailingSlash(path: string) {
 export function isPathInWorkspace(path: string) {
 	let rootsExact = [], rootsFolder = [], workspaceFolders = vscode.workspace.workspaceFolders;
 	if (typeof workspaceFolders !== 'undefined') {
-		for (let i = 0; i < workspaceFolders.length; i++) {
+		for (let i = 0, length = workspaceFolders.length; i < length; i++) {
 			let tmpPath = getPathFromUri(workspaceFolders[i].uri);
 			rootsExact.push(tmpPath);
 			rootsFolder.push(pathWithTrailingSlash(tmpPath));
@@ -80,7 +80,7 @@ export function realpath(path: string, native: boolean = false) {
 export async function resolveToSymbolicPath(path: string) {
 	let workspaceFolders = vscode.workspace.workspaceFolders;
 	if (typeof workspaceFolders !== 'undefined') {
-		for (let i = 0; i < workspaceFolders.length; i++) {
+		for (let i = 0, length = workspaceFolders.length; i < length; i++) {
 			let rootSymPath = getPathFromUri(workspaceFolders[i].uri);
 			let rootCanonicalPath = await realpath(rootSymPath);
 			if (path === rootCanonicalPath) {
@@ -476,7 +476,7 @@ export function evalPromises<X, Y>(data: X[], maxParallel: number, createPromise
 					rejected = true;
 				});
 			}
-			for (let i = 0; i < maxParallel && i < data.length; i++) startNext();
+			for (let i = 0, length = data.length; i < maxParallel && i < length; i++) startNext();
 		}
 	});
 }
@@ -608,7 +608,7 @@ async function findGitWin32InPath() {
 	let dirs = (process.env['PATH'] || '').split(';');
 	dirs.unshift(process.cwd());
 
-	for (let i = 0; i < dirs.length; i++) {
+	for (let i = 0, length = dirs.length; i < length; i++) {
 		let file = path.join(dirs[i], 'git.exe');
 		if (await isExecutable(file)) {
 			try {
@@ -655,7 +655,7 @@ export function getGitExecutable(path: string) {
  * @returns The GitExecutable data.
  */
 export async function getGitExecutableFromPaths(paths: string[]): Promise<GitExecutable> {
-	for (let i = 0; i < paths.length; i++) {
+	for (let i = 0, length = paths.length; i < length; i++) {
 		try {
 			return await getGitExecutable(paths[i]);
 		} catch (_) { }

--- a/web/contextMenu.ts
+++ b/web/contextMenu.ts
@@ -49,9 +49,9 @@ class ContextMenu {
 		let html = '', handlers: (() => void)[] = [], handlerId = 0;
 		this.close();
 
-		for (let i = 0; i < actions.length; i++) {
+		for (let i = 0, length = actions.length; i < length; i++) {
 			let groupHtml = '';
-			for (let j = 0; j < actions[i].length; j++) {
+			for (let j = 0, length = actions[i].length; j < length; j++) {
 				if (actions[i][j].visible) {
 					groupHtml += '<li class="contextMenuItem" data-index="' + handlerId++ + '">' + (checked ? '<span class="contextMenuItemCheck">' + (actions[i][j].checked ? SVG_ICONS.check : '') + '</span>' : '') + actions[i][j].title + '</li>';
 					handlers.push(actions[i][j].onClick);
@@ -147,7 +147,7 @@ class ContextMenu {
 				} else {
 					// ContextMenu is dependent on the commit and ref 
 					const elems = <NodeListOf<HTMLElement>>commitElem.querySelectorAll('[data-fullref]');
-					for (let i = 0; i < elems.length; i++) {
+					for (let i = 0, length = elems.length; i < length; i++) {
 						if (elems[i].dataset.fullref! === this.target.ref) {
 							this.target.elem = this.target.type === TargetType.Ref ? elems[i] : commitElem;
 							alterClass(this.target.elem, CLASS_CONTEXT_MENU_ACTIVE, true);

--- a/web/dialog.ts
+++ b/web/dialog.ts
@@ -227,7 +227,7 @@ class Dialog {
 			if (input.type === DialogInputType.Radio) {
 				// Iterate through all of the radio options to get the checked value
 				const elems = <NodeListOf<HTMLInputElement>>document.getElementsByName('dialogInput' + index);
-				for (let i = 0; i < elems.length; i++) {
+				for (let i = 0, length = elems.length; i < length; i++) {
 					if (elems[i].checked) {
 						return input.options[parseInt(elems[i].value)].value;
 					}
@@ -413,7 +413,7 @@ class Dialog {
 				} else {
 					// Dialog is dependent on the commit and ref 
 					const elems = <NodeListOf<HTMLElement>>commitElem.querySelectorAll('[data-fullref]');
-					for (let i = 0; i < elems.length; i++) {
+					for (let i = 0, length = elems.length; i < length; i++) {
 						if (elems[i].dataset.fullref! === this.target.ref) {
 							this.target.elem = this.target.type === TargetType.Ref ? elems[i] : commitElem;
 							alterClass(this.target.elem, CLASS_DIALOG_ACTIVE, true);
@@ -699,7 +699,7 @@ class CustomSelect {
 	private renderOptionsStates() {
 		if (this.optionsElem !== null) {
 			let optionElems = this.optionsElem.children, elemIndex: number;
-			for (let i = 0; i < optionElems.length; i++) {
+			for (let i = 0, length = optionElems.length; i < length; i++) {
 				elemIndex = parseInt((<HTMLElement>optionElems[i]).dataset.index!);
 				alterClass(<HTMLElement>optionElems[i], CLASS_SELECTED, this.selected[elemIndex]);
 				alterClass(<HTMLElement>optionElems[i], CLASS_FOCUSSED, this.focussed === elemIndex);
@@ -715,7 +715,7 @@ class CustomSelect {
 	private getOptionElem(index: number) {
 		if (this.optionsElem !== null && index > -1) {
 			const optionElems = this.optionsElem.children, indexStr = index.toString();
-			for (let i = 0; i < optionElems.length; i++) {
+			for (let i = 0, length = optionElems.length; i < length; i++) {
 				if ((<HTMLElement>optionElems[i]).dataset.index === indexStr) {
 					return <HTMLElement>optionElems[i];
 				}

--- a/web/dropdown.ts
+++ b/web/dropdown.ts
@@ -99,7 +99,7 @@ class Dropdown {
 		this.optionsSelected = [];
 		this.numSelected = 0;
 		let selectedOption = -1, isSelected;
-		for (let i = 0; i < options.length; i++) {
+		for (let i = 0, length = options.length; i < length; i++) {
 			isSelected = optionsSelected.includes(options[i].value);
 			this.optionsSelected[i] = isSelected;
 			if (isSelected) {
@@ -153,7 +153,7 @@ class Dropdown {
 		this.currentValueElem.innerHTML = escapeHtml(curValueText);
 
 		let html = '';
-		for (let i = 0; i < this.options.length; i++) {
+		for (let i = 0, length = this.options.length; i < length; i++) {
 			const escapedName = escapeHtml(this.options[i].name);
 			html += '<div class="dropdownOption' + (this.optionsSelected[i] ? ' ' + CLASS_SELECTED : '') + '" data-id="' + i + '" title="' + escapedName + '">' +
 				(this.multipleAllowed && this.optionsSelected[i] ? '<div class="dropdownOptionMultiSelected">' + SVG_ICONS.check + '</div>' : '') +
@@ -179,7 +179,7 @@ class Dropdown {
 	 */
 	private filter() {
 		let val = this.filterInput.value.toLowerCase(), match, matches = false;
-		for (let i = 0; i < this.options.length; i++) {
+		for (let i = 0, length = this.options.length; i < length; i++) {
 			match = this.options[i].name.toLowerCase().indexOf(val) > -1;
 			(<HTMLElement>this.optionsElem.children[i]).style.display = match ? 'block' : 'none';
 			if (match) matches = true;
@@ -199,7 +199,7 @@ class Dropdown {
 			// Note: Show All is always the first option (0 index) when multiple selected items are allowed
 			return [names ? this.options[0].name : this.options[0].value];
 		}
-		for (let i = 0; i < this.options.length; i++) {
+		for (let i = 0, length = this.options.length; i < length; i++) {
 			if (this.optionsSelected[i]) selected.push(names ? this.options[i].name : this.options[i].value);
 		}
 		return selected;
@@ -219,7 +219,7 @@ class Dropdown {
 			// Double click
 			if (this.multipleAllowed && option === 0) {
 				this.numSelected = 1;
-				for (let i = 1; i < this.optionsSelected.length; i++) {
+				for (let i = 1, length = this.optionsSelected.length; i < length; i++) {
 					this.optionsSelected[i] = !this.optionsSelected[i];
 					if (this.optionsSelected[i]) this.numSelected++;
 				}
@@ -233,7 +233,7 @@ class Dropdown {
 					// Show All was selected
 					if (!this.optionsSelected[0]) {
 						this.optionsSelected[0] = true;
-						for (let i = 1; i < this.optionsSelected.length; i++) {
+						for (let i = 1, length = this.optionsSelected.length; i < length; i++) {
 							this.optionsSelected[i] = false;
 						}
 						this.numSelected = 1;

--- a/web/findWidget.ts
+++ b/web/findWidget.ts
@@ -231,7 +231,7 @@ class FindWidget {
 
 				// Search the commit data itself to detect commits that match, so that dom tree traversal is performed on matching commit rows (for performance)
 				const commits = this.view.getCommits();
-				for (let i = 0; i < commits.length; i++) {
+				for (let i = 0, length = commits.length; i < length; i++) {
 					commit = commits[i];
 					let branchLabels = getBranchLabels(commit.heads, commit.remotes);
 					if (commit.hash !== UNCOMMITTED && ((colVisibility.author && findPattern.test(commit.author))
@@ -251,7 +251,7 @@ class FindWidget {
 
 						// Highlight matches
 						let textElems = getChildNodesWithTextContent(commitElems[j]), textElem;
-						for (let k = 0; k < textElems.length; k++) {
+						for (let k = 0, length = textElems.length; k < length; k++) {
 							textElem = textElems[k];
 							let matchStart = 0, matchEnd = 0, text = textElem.textContent!, match: RegExpExecArray | null;
 							findGlobalPattern.lastIndex = 0;
@@ -324,10 +324,10 @@ class FindWidget {
 	 * Clear all of the highlighted find matches in the view.
 	 */
 	private clearMatches() {
-		for (let i = 0; i < this.matches.length; i++) {
+		for (let i = 0, length = this.matches.length; i < length; i++) {
 			if (i === this.position) this.matches[i].elem.classList.remove(CLASS_FIND_CURRENT_COMMIT);
 			let matchElems = getChildrenWithClassName(this.matches[i].elem, CLASS_FIND_MATCH), matchElem;
-			for (let j = 0; j < matchElems.length; j++) {
+			for (let j = 0, length = matchElems.length; j < length; j++) {
 				matchElem = matchElems[j];
 				let text = matchElem.childNodes[0].textContent!;
 

--- a/web/graph.ts
+++ b/web/graph.ts
@@ -259,7 +259,7 @@ class Vertex {
 	}
 
 	public getPointConnectingTo(vertex: VertexOrNull, onBranch: Branch) {
-		for (let i = 0; i < this.connections.length; i++) {
+		for (let i = 0, length = this.connections.length; i < length; i++) {
 			if (this.connections[i].connectsTo === vertex && this.connections[i].onBranch === onBranch) {
 				return { x: i, y: this.id };
 			}
@@ -539,7 +539,7 @@ class Graph {
 
 			visited[idStr] = vertex.id;
 			let children = vertex.getChildren();
-			for (let i = 0; i < children.length; i++) rec(children[i]);
+			for (let i = 0, length = children.length; i < length; i++) rec(children[i]);
 		};
 		rec(this.vertices[i]);
 		return Object.keys(visited).map((key) => visited[key]).sort((a, b) => a - b);
@@ -547,13 +547,13 @@ class Graph {
 
 	public getMutedCommits(currentHash: string | null) {
 		const muted = [];
-		for (let i = 0; i < this.commits.length; i++) {
+		for (let i = 0, length = this.commits.length; i < length; i++) {
 			muted[i] = false;
 		}
 
 		// Mute any merge commits if the Extension Setting is enabled
 		if (this.muteConfig.mergeCommits) {
-			for (let i = 0; i < this.commits.length; i++) {
+			for (let i = 0, length = this.commits.length; i < length; i++) {
 				if (this.vertices[i].isMerge() && this.commits[i].stash === null) {
 					// The commit is a merge, and is not a stash
 					muted[i] = true;
@@ -564,7 +564,7 @@ class Graph {
 		// Mute any commits that are not ancestors of the commit head if the Extension Setting is enabled, and the head commit is in the graph
 		if (this.muteConfig.commitsNotAncestorsOfHead && currentHash !== null && typeof this.commitLookup[currentHash] === 'number') {
 			let ancestor: boolean[] = [];
-			for (let i = 0; i < this.commits.length; i++) {
+			for (let i = 0, length = this.commits.length; i < length; i++) {
 				ancestor[i] = false;
 			}
 
@@ -574,11 +574,11 @@ class Graph {
 				ancestor[vertex.id] = true;
 
 				let parents = vertex.getParents();
-				for (let i = 0; i < parents.length; i++) rec(parents[i]);
+				for (let i = 0, length = parents.length; i < length; i++) rec(parents[i]);
 			};
 			rec(this.vertices[this.commitLookup[currentHash]]);
 
-			for (let i = 0; i < this.commits.length; i++) {
+			for (let i = 0, length = this.commits.length; i < length; i++) {
 				if (!ancestor[i] && (this.commits[i].stash === null || typeof this.commitLookup[this.commits[i].stash!.baseHash] !== 'number' || !ancestor[this.commitLookup[this.commits[i].stash!.baseHash]])) {
 					// Commit i is not an ancestor of currentHash, or a stash based on an ancestor of currentHash
 					muted[i] = true;
@@ -763,7 +763,7 @@ class Graph {
 	}
 
 	private getAvailableColour(startAt: number) {
-		for (let i = 0; i < this.availableColours.length; i++) {
+		for (let i = 0, length = this.availableColours.length; i < length; i++) {
 			if (startAt > this.availableColours[i]) {
 				return i;
 			}
@@ -811,11 +811,11 @@ class Graph {
 
 		const children = this.getAllChildren(id);
 		let heads: string[] = [], remotes: GG.GitCommitRemote[] = [], stashes: string[] = [], tags: string[] = [], childrenIncludesHead = false;
-		for (let i = 0; i < children.length; i++) {
+		for (let i = 0, length = children.length; i < length; i++) {
 			let commit = this.commits[children[i]];
-			for (let j = 0; j < commit.heads.length; j++) heads.push(commit.heads[j]);
-			for (let j = 0; j < commit.remotes.length; j++) remotes.push(commit.remotes[j]);
-			for (let j = 0; j < commit.tags.length; j++) tags.push(commit.tags[j].name);
+			for (let j = 0, length = commit.heads.length; j < length; j++) heads.push(commit.heads[j]);
+			for (let j = 0, length = commit.remotes.length; j < length; j++) remotes.push(commit.remotes[j]);
+			for (let j = 0, length = commit.tags.length; j < length; j++) tags.push(commit.tags[j].name);
 			if (commit.stash !== null) stashes.push(commit.stash.selector.substring(5));
 			if (commit.hash === this.commitHead) childrenIncludesHead = true;
 		}

--- a/web/main.ts
+++ b/web/main.ts
@@ -500,7 +500,7 @@ class GitGraphView {
 		this.avatars[email] = image;
 		this.saveState();
 		let avatarsElems = <HTMLCollectionOf<HTMLElement>>document.getElementsByClassName('avatar'), escapedEmail = escapeHtml(email);
-		for (let i = 0; i < avatarsElems.length; i++) {
+		for (let i = 0, length = avatarsElems.length; i < length; i++) {
 			if (avatarsElems[i].dataset.email === escapedEmail) {
 				avatarsElems[i].innerHTML = '<img class="avatarImg" src="' + image + '">';
 			}
@@ -519,10 +519,10 @@ class GitGraphView {
 		if (includeShowAll) {
 			options.push({ name: 'Show All', value: SHOW_ALL_BRANCHES });
 		}
-		for (let i = 0; i < this.config.customBranchGlobPatterns.length; i++) {
+		for (let i = 0, length = this.config.customBranchGlobPatterns.length; i < length; i++) {
 			options.push({ name: 'Glob: ' + this.config.customBranchGlobPatterns[i].name, value: this.config.customBranchGlobPatterns[i].glob });
 		}
-		for (let i = 0; i < this.gitBranches.length; i++) {
+		for (let i = 0, length = this.gitBranches.length; i < length; i++) {
 			options.push({ name: this.gitBranches[i].indexOf('remotes/') === 0 ? this.gitBranches[i].substring(8) : this.gitBranches[i], value: this.gitBranches[i] });
 		}
 		return options;
@@ -676,7 +676,7 @@ class GitGraphView {
 
 	private requestAvatars(avatars: { [email: string]: string[] }) {
 		let emails = Object.keys(avatars), remote = this.gitRemotes.length > 0 ? this.gitRemotes.includes('origin') ? 'origin' : this.gitRemotes[0] : null;
-		for (let i = 0; i < emails.length; i++) {
+		for (let i = 0, length = emails.length; i < length; i++) {
 			sendMessage({ command: 'fetchAvatar', repo: this.currentRepo, remote: remote, email: emails[i], commits: avatars[emails[i]] });
 		}
 	}
@@ -814,7 +814,7 @@ class GitGraphView {
 			(colVisibility.commit ? '<th class="tableColHeader" data-col="4">Commit</th>' : '') +
 			'</tr>';
 
-		for (let i = 0; i < this.commits.length; i++) {
+		for (let i = 0, length = this.commits.length; i < length; i++) {
 			let commit = this.commits[i];
 			let message = '<span class="text">' + textFormatter.format(commit.message) + '</span>';
 			let date = formatShortDate(commit.date);
@@ -1081,7 +1081,7 @@ class GitGraphView {
 					const dialogConfig = this.config.dialogDefaults.addTag;
 
 					let mostRecentTagsIndex = -1;
-					for (let i = 0; i < this.commits.length; i++) {
+					for (let i = 0, length = this.commits.length; i < length; i++) {
 						if (this.commits[i].tags.length > 0 && (mostRecentTagsIndex === -1 || this.commits[i].date > this.commits[mostRecentTagsIndex].date)) {
 							mostRecentTagsIndex = i;
 						}
@@ -1586,7 +1586,7 @@ class GitGraphView {
 		const makeTableFixedLayout = () => {
 			cols[0].style.width = columnWidths[0] + 'px';
 			cols[0].style.padding = '';
-			for (let i = 2; i < cols.length; i++) {
+			for (let i = 2, length = cols.length; i < length; i++) {
 				cols[i].style.width = columnWidths[parseInt(cols[i].dataset.col!)] + 'px';
 			}
 			this.tableElem.className = 'fixedLayout';
@@ -1594,7 +1594,7 @@ class GitGraphView {
 			this.graph.limitMaxWidth(columnWidths[0] + COLUMN_LEFT_RIGHT_PADDING);
 		};
 
-		for (let i = 0; i < cols.length; i++) {
+		for (let i = 0, length = cols.length; i < length; i++) {
 			let col = parseInt(cols[i].dataset.col!);
 			cols[i].innerHTML += (i > 0 ? '<span class="resizeCol left" data-col="' + (col - 1) + '"></span>' : '') + (i < cols.length - 1 ? '<span class="resizeCol right" data-col="' + col + '"></span>' : '');
 		}
@@ -1677,7 +1677,7 @@ class GitGraphView {
 			mouseX = (<MouseEvent>e).clientX;
 
 			let isAuto = columnWidths[0] === COLUMN_AUTO;
-			for (let i = 0; i < cols.length; i++) {
+			for (let i = 0, length = cols.length; i < length; i++) {
 				let curCol = parseInt(cols[i].dataset.col!);
 				if (isAuto && curCol !== 1) columnWidths[curCol] = cols[i].clientWidth - COLUMN_LEFT_RIGHT_PADDING;
 				if (curCol === col) colIndex = i;
@@ -3155,7 +3155,7 @@ window.addEventListener('load', () => {
 
 	function reduceErrorInfos(errors: GG.ErrorInfo[]) {
 		let error: GG.ErrorInfo = null, partialOrCompleteSuccess = false;
-		for (let i = 0; i < errors.length; i++) {
+		for (let i = 0, length = errors.length; i < length; i++) {
 			if (errors[i] !== null) {
 				error = error !== null ? error + '\n\n' + errors[i] : errors[i];
 			} else {
@@ -3208,7 +3208,7 @@ function generateFileListHtml(folder: FileTreeFolder, gitFiles: ReadonlyArray<GG
 	const sortLeaves = (folder: FileTreeFolder, folderPath: string) => {
 		let keys = sortFolderKeys(folder);
 		let items: { relPath: string, leaf: FileTreeLeaf }[] = [];
-		for (let i = 0; i < keys.length; i++) {
+		for (let i = 0, length = keys.length; i < length; i++) {
 			let cur = folder.contents[keys[i]];
 			let relPath = (folderPath !== '' ? folderPath + '/' : '') + cur.name;
 			if (cur.type === 'folder') {
@@ -3221,7 +3221,7 @@ function generateFileListHtml(folder: FileTreeFolder, gitFiles: ReadonlyArray<GG
 	};
 	let sortedLeaves = sortLeaves(folder, '');
 	let html = '';
-	for (let i = 0; i < sortedLeaves.length; i++) {
+	for (let i = 0, length = sortedLeaves.length; i < length; i++) {
 		html += generateFileTreeLeafHtml(sortedLeaves[i].relPath, sortedLeaves[i].leaf, gitFiles, lastViewedFile, fileContextMenuOpen, isUncommitted);
 	}
 	return '<ul class="fileTreeFolderContents">' + html + '</ul>';
@@ -3277,7 +3277,7 @@ function alterFileTreeFileReviewed(folder: FileTreeFolder, filePath: string) {
 	}
 	for (i = folders.length - 1; i >= 0; i--) {
 		let keys = Object.keys(folders[i].contents), reviewed = true;
-		for (let j = 0; j < keys.length; j++) {
+		for (let j = 0, length = keys.length; j < length; j++) {
 			let cur = folders[i].contents[keys[j]];
 			if ((cur.type === 'folder' || cur.type === 'file') && !cur.reviewed) {
 				reviewed = false;
@@ -3291,7 +3291,7 @@ function alterFileTreeFileReviewed(folder: FileTreeFolder, filePath: string) {
 function setFileTreeReviewed(folder: FileTreeFolder, reviewed: boolean) {
 	folder.reviewed = reviewed;
 	let keys = Object.keys(folder.contents);
-	for (let i = 0; i < keys.length; i++) {
+	for (let i = 0, length = keys.length; i < length; i++) {
 		let cur = folder.contents[keys[i]];
 		if (cur.type === 'folder') {
 			setFileTreeReviewed(cur, reviewed);
@@ -3305,7 +3305,7 @@ function calcFileTreeFoldersReviewed(folder: FileTreeFolder) {
 	const calc = (folder: FileTreeFolder) => {
 		let reviewed = true;
 		let keys = Object.keys(folder.contents);
-		for (let i = 0; i < keys.length; i++) {
+		for (let i = 0, length = keys.length; i < length; i++) {
 			let cur = folder.contents[keys[i]];
 			if ((cur.type === 'folder' && !calc(cur)) || (cur.type === 'file' && !cur.reviewed)) reviewed = false;
 		}
@@ -3319,7 +3319,7 @@ function updateFileTreeHtml(elem: HTMLElement, folder: FileTreeFolder) {
 	let ul = getChildUl(elem);
 	if (ul === null) return;
 
-	for (let i = 0; i < ul.children.length; i++) {
+	for (let i = 0, length = ul.children.length; i < length; i++) {
 		let li = <HTMLLIElement>ul.children[i];
 		let pathSeg = decodeURIComponent(li.dataset.pathseg!);
 		let child = getChildByPathSegment(folder, pathSeg);
@@ -3338,7 +3338,7 @@ function updateFileTreeHtmlFileReviewed(elem: HTMLElement, folder: FileTreeFolde
 		let ul = getChildUl(elem);
 		if (ul === null) return;
 
-		for (let i = 0; i < ul.children.length; i++) {
+		for (let i = 0, length = ul.children.length; i < length; i++) {
 			let li = <HTMLLIElement>ul.children[i];
 			let pathSeg = decodeURIComponent(li.dataset.pathseg!);
 			if (path === pathSeg || path.startsWith(pathSeg + '/')) {
@@ -3361,7 +3361,7 @@ function getFilesInTree(folder: FileTreeFolder, gitFiles: ReadonlyArray<GG.GitFi
 	let files: string[] = [];
 	const scanFolder = (folder: FileTreeFolder) => {
 		let keys = Object.keys(folder.contents);
-		for (let i = 0; i < keys.length; i++) {
+		for (let i = 0, length = keys.length; i < length; i++) {
 			let cur = folder.contents[keys[i]];
 			if (cur.type === 'folder') {
 				scanFolder(cur);
@@ -3382,7 +3382,7 @@ function sortFolderKeys(folder: FileTreeFolder) {
 
 function getChildByPathSegment(folder: FileTreeFolder, pathSeg: string) {
 	let cur: FileTreeNode = folder, comps = pathSeg.split('/');
-	for (let i = 0; i < comps.length; i++) {
+	for (let i = 0, length = comps.length; i < length; i++) {
 		cur = (<FileTreeFolder>cur).contents[comps[i]];
 	}
 	return cur;
@@ -3469,7 +3469,7 @@ function getRepoDropdownOptions(repos: Readonly<GG.GitRepoSet>) {
 	const resolveAmbiguous = (indexes: number[]) => {
 		// Find ambiguous names within indexes
 		let firstOccurrence: { [name: string]: number } = {}, ambiguous: { [name: string]: number[] } = {};
-		for (let i = 0; i < indexes.length; i++) {
+		for (let i = 0, length = indexes.length; i < length; i++) {
 			let name = distinctNames[indexes[i]];
 			if (typeof firstOccurrence[name] === 'number') {
 				// name is ambiguous
@@ -3484,10 +3484,10 @@ function getRepoDropdownOptions(repos: Readonly<GG.GitRepoSet>) {
 		}
 
 		let ambiguousNames = Object.keys(ambiguous);
-		for (let i = 0; i < ambiguousNames.length; i++) {
+		for (let i = 0, length = ambiguousNames.length; i < length; i++) {
 			// For each ambiguous name, resolve the ambiguous indexes
 			let ambiguousIndexes = ambiguous[ambiguousNames[i]], retestIndexes = [];
-			for (let j = 0; j < ambiguousIndexes.length; j++) {
+			for (let j = 0, length = ambiguousIndexes.length; j < length; j++) {
 				let ambiguousIndex = ambiguousIndexes[j];
 				let nextSep = paths[ambiguousIndex].lastIndexOf('/', paths[ambiguousIndex].length - distinctNames[ambiguousIndex].length - 2);
 				if (firstSep[ambiguousIndex] < nextSep) {
@@ -3507,7 +3507,7 @@ function getRepoDropdownOptions(repos: Readonly<GG.GitRepoSet>) {
 
 	// Initialise recursion
 	let indexes = [];
-	for (let i = 0; i < repoPaths.length; i++) {
+	for (let i = 0, length = repoPaths.length; i < length; i++) {
 		firstSep.push(repoPaths[i].indexOf('/'));
 		const repo = repos[repoPaths[i]];
 		if (repo.name !== null) {
@@ -3531,7 +3531,7 @@ function getRepoDropdownOptions(repos: Readonly<GG.GitRepoSet>) {
 	resolveAmbiguous(indexes);
 
 	let options: DropdownOption[] = [];
-	for (let i = 0; i < repoPaths.length; i++) {
+	for (let i = 0, length = repoPaths.length; i < length; i++) {
 		let hint;
 		if (names[i] === distinctNames[i]) {
 			// Name is distinct, no hint needed
@@ -3563,13 +3563,13 @@ function runAction(msg: GG.RequestMessage, action: string) {
 
 function getBranchLabels(heads: ReadonlyArray<string>, remotes: ReadonlyArray<GG.GitCommitRemote>) {
 	let headLabels: { name: string; remotes: string[] }[] = [], headLookup: { [name: string]: number } = {}, remoteLabels: ReadonlyArray<GG.GitCommitRemote>;
-	for (let i = 0; i < heads.length; i++) {
+	for (let i = 0, length = heads.length; i < length; i++) {
 		headLabels.push({ name: heads[i], remotes: [] });
 		headLookup[heads[i]] = i;
 	}
 	if (initialState.config.referenceLabels.combineLocalAndRemoteBranchLabels) {
 		let remainingRemoteLabels = [];
-		for (let i = 0; i < remotes.length; i++) {
+		for (let i = 0, length = remotes.length; i < length; i++) {
 			if (remotes[i].remote !== null) { // If the remote of the remote branch ref is known
 				let branchName = remotes[i].name.substring(remotes[i].remote!.length + 1);
 				if (typeof headLookup[branchName] === 'number') {
@@ -3589,7 +3589,7 @@ function getBranchLabels(heads: ReadonlyArray<string>, remotes: ReadonlyArray<GG
 function findCommitElemWithId(elems: HTMLCollectionOf<HTMLElement>, id: number | null) {
 	if (id === null) return null;
 	let findIdStr = id.toString();
-	for (let i = 0; i < elems.length; i++) {
+	for (let i = 0, length = elems.length; i < length; i++) {
 		if (findIdStr === elems[i].dataset.id) return elems[i];
 	}
 	return null;

--- a/web/textFormatter.ts
+++ b/web/textFormatter.ts
@@ -388,7 +388,7 @@ class TextFormatter {
 			}
 			const emphasisStack: TF.EmphasisDelimiter[] = [];
 			let stackMatch: number;
-			for (let i = 0; i < emphasisTokens.length; i++) {
+			for (let i = 0, length = emphasisTokens.length; i < length; i++) {
 				const delimiter = emphasisTokens[i];
 				const run = emphasisRuns[delimiter.run];
 				if (run.close && (stackMatch = TextFormatter.findOpenEmphasis(delimiter, run, emphasisRuns, emphasisStack)) > -1) {
@@ -465,7 +465,7 @@ class TextFormatter {
 	 */
 	public static registerCustomEmojiMappings(mappings: ReadonlyArray<GG.CustomEmojiShortcodeMapping>) {
 		const validShortcodeRegExp = /^:[A-Za-z0-9-_]+:$/;
-		for (let i = 0; i < mappings.length; i++) {
+		for (let i = 0, length = mappings.length; i < length; i++) {
 			if (validShortcodeRegExp.test(mappings[i].shortcode)) {
 				TextFormatter.EMOJI_MAPPINGS[mappings[i].shortcode.substring(1, mappings[i].shortcode.length - 1)] = mappings[i].emoji;
 			}
@@ -512,7 +512,7 @@ class TextFormatter {
 	 */
 	private static insertIntoTree(tree: TF.Node, node: TF.Node) {
 		let firstChildIndexOfNode = -1, lastChildIndexOfNode = -1, curNode;
-		for (let i = 0; i < tree.contains.length; i++) {
+		for (let i = 0, length = tree.contains.length; i < length; i++) {
 			curNode = tree.contains[i];
 			if (node.start < curNode.start && firstChildIndexOfNode === -1) {
 				firstChildIndexOfNode = i;
@@ -540,7 +540,7 @@ class TextFormatter {
 	 */
 	private static insertIntoTreeIfNoOverlap(tree: TF.RootNode, node: TF.Node) {
 		let curNode: TF.Node, insertAtIndex = tree.contains.length;
-		for (let i = 0; i < tree.contains.length; i++) {
+		for (let i = 0, length = tree.contains.length; i < length; i++) {
 			curNode = tree.contains[i];
 			if ((curNode.start <= node.start && node.start <= curNode.end) || (curNode.start <= node.end && node.end <= curNode.end) || (node.start <= curNode.start && curNode.end <= node.end)) {
 				return;

--- a/web/utils.ts
+++ b/web/utils.ts
@@ -112,7 +112,7 @@ const ATTR_ERROR = 'data-error';
  */
 function arraysEqual<T>(a: ReadonlyArray<T>, b: ReadonlyArray<T>, equalElements: (a: T, b: T) => boolean) {
 	if (a.length !== b.length) return false;
-	for (let i = 0; i < a.length; i++) {
+	for (let i = 0, length = a.length; i < length; i++) {
 		if (!equalElements(a[i], b[i])) return false;
 	}
 	return true;
@@ -126,7 +126,7 @@ function arraysEqual<T>(a: ReadonlyArray<T>, b: ReadonlyArray<T>, equalElements:
  */
 function arraysStrictlyEqual<T>(a: ReadonlyArray<T>, b: ReadonlyArray<T>) {
 	if (a.length !== b.length) return false;
-	for (let i = 0; i < a.length; i++) {
+	for (let i = 0, length = a.length; i < length; i++) {
 		if (a[i] !== b[i]) return false;
 	}
 	return true;
@@ -140,7 +140,7 @@ function arraysStrictlyEqual<T>(a: ReadonlyArray<T>, b: ReadonlyArray<T>) {
  */
 function arraysStrictlyEqualIgnoringOrder<T>(a: ReadonlyArray<T>, b: ReadonlyArray<T>) {
 	if (a.length !== b.length) return false;
-	for (let i = 0; i < a.length; i++) {
+	for (let i = 0, length = a.length; i < length; i++) {
 		if (b.indexOf(a[i]) === -1) return false;
 	}
 	return true;
@@ -226,7 +226,7 @@ function unescapeHtml(str: string) {
  */
 function formatCommaSeparatedList(items: string[]) {
 	let str = '';
-	for (let i = 0; i < items.length; i++) {
+	for (let i = 0, length = items.length; i < length; i++) {
 		str += (i > 0 ? (i < items.length - 1 ? ', ' : ' & ') : '') + items[i];
 	}
 	return str;
@@ -318,7 +318,7 @@ function addListenerToClass(className: string, event: string, eventListener: Eve
  * @param eventListener The event listener to be called when the event occurs.
  */
 function addListenerToCollectionElems(elems: HTMLCollectionOf<Element>, event: string, eventListener: EventListener) {
-	for (let i = 0; i < elems.length; i++) {
+	for (let i = 0, length = elems.length; i < length; i++) {
 		elems[i].addEventListener(event, eventListener);
 	}
 }
@@ -340,7 +340,7 @@ function insertAfter(newNode: HTMLElement, referenceNode: HTMLElement) {
  */
 function insertBeforeFirstChildWithClass(newChild: HTMLElement, parent: HTMLElement, className: string) {
 	let referenceNode: Node | null = null;
-	for (let i = 0; i < parent.children.length; i++) {
+	for (let i = 0, length = parent.children.length; i < length; i++) {
 		if (parent.children[i].classList.contains(className)) {
 			referenceNode = parent.children[i];
 			break;
@@ -376,10 +376,10 @@ function alterClass(elem: HTMLElement, className: string, state: boolean) {
  */
 function alterClassOfCollection(elems: HTMLCollectionOf<HTMLElement>, className: string, state: boolean) {
 	const lockedElems = [];
-	for (let i = 0; i < elems.length; i++) {
+	for (let i = 0, length = elems.length; i < length; i++) {
 		lockedElems.push(elems[i]);
 	}
-	for (let i = 0; i < lockedElems.length; i++) {
+	for (let i = 0, length = lockedElems.length; i < length; i++) {
 		alterClass(lockedElems[i], className, state);
 	}
 }
@@ -391,7 +391,7 @@ function alterClassOfCollection(elems: HTMLCollectionOf<HTMLElement>, className:
  */
 function getChildNodesWithTextContent(elem: Node) {
 	let textChildren: Node[] = [];
-	for (let i = 0; i < elem.childNodes.length; i++) {
+	for (let i = 0, length = elem.childNodes.length; i < length; i++) {
 		if (elem.childNodes[i].childNodes.length > 0) {
 			textChildren.push(...getChildNodesWithTextContent(elem.childNodes[i]));
 		} else if (elem.childNodes[i].textContent !== null && elem.childNodes[i].textContent !== '') {
@@ -409,7 +409,7 @@ function getChildNodesWithTextContent(elem: Node) {
  */
 function getChildrenWithClassName(elem: Element, className: string) {
 	let children: Element[] = [];
-	for (let i = 0; i < elem.children.length; i++) {
+	for (let i = 0, length = elem.children.length; i < length; i++) {
 		if (elem.children[i].children.length > 0) {
 			children.push(...getChildrenWithClassName(elem.children[i], className));
 		} else if (elem.children[i].className === className) {
@@ -425,7 +425,7 @@ function getChildrenWithClassName(elem: Element, className: string) {
  * @returns The HTML Element, or NULL if no child is a \<ul\>.
  */
 function getChildUl(elem: HTMLElement) {
-	for (let i = 0; i < elem.children.length; i++) {
+	for (let i = 0, length = elem.children.length; i < length; i++) {
 		if (elem.children[i].tagName === 'UL') {
 			return <HTMLUListElement>elem.children[i];
 		}


### PR DESCRIPTION
Summary of the issue:

For loops are set up in such a way that the length value to compare the index against is recalculated on each pass. This is a minor performance issue that can be very easily improved.

Description outlining how this pull request resolves the issue:

All for loops that declare an index variable in the loop itself now also declare a fixed length variable once and use that variable to compare the index against. This covers not all for loops but most of them. The others would need a little extra attention as their index variable was declared before the loop which requires a different approach for declaring the length variable.