### PR TITLE
#557 Change contextMenuItem `click` to `mouseup`

### DIFF
--- a/web/contextMenu.ts
+++ b/web/contextMenu.ts
@@ -88,7 +88,7 @@ class ContextMenu {
 		this.elem = menu;
 		this.onClose = onClose;
 
-		addListenerToClass('contextMenuItem', 'click', (e) => {
+		addListenerToClass('contextMenuItem', 'mouseup', (e) => {
 			e.stopPropagation();
 			this.close();
 			handlers[parseInt((<HTMLElement>(<Element>e.target).closest('.contextMenuItem')!).dataset.index!)]();


### PR DESCRIPTION
Issue Number / Link: 
#557

Summary of the issue:
Change contextMenuItem `click` to `mouseup`

Description outlining how this pull request resolves the issue:
Changes contextMenuItem  `click` to `mouseup` listener