### PR TITLE
Change abbreviated commit hash length to 7 chars

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -120,12 +120,12 @@ export function doesFileExist(path: string) {
 /* General Methods */
 
 /**
- * Abbreviate a commit hash to the first eight characters.
+ * Abbreviate a commit hash to the first seven characters.
  * @param commitHash The full commit hash.
  * @returns The abbreviated commit hash.
  */
 export function abbrevCommit(commitHash: string) {
-	return commitHash.substring(0, 8);
+	return commitHash.substring(0, 7);
 }
 
 /**

--- a/web/main.ts
+++ b/web/main.ts
@@ -3814,7 +3814,7 @@ function haveFilesChanged(oldFiles: ReadonlyArray<GG.GitFileChange> | null, newF
 }
 
 function abbrevCommit(commitHash: string) {
-	return commitHash.substring(0, 8);
+	return commitHash.substring(0, 7);
 }
 
 function getRepoDropdownOptions(repos: Readonly<GG.GitRepoSet>) {


### PR DESCRIPTION
Summary of the issue:

Abbreviated commit length across the software is 8 chars, but git usually uses 7 chars. For better compatibility the abbrev commit hash function should be reduced to 7 chars.

Description outlining how this pull request resolves the issue:
Change `abbrevCommit()` function to substring(0, 7);