### PR TITLE
Add "Copy short Commit Hash to Clipboard" button

### DIFF
--- a/web/main.ts
+++ b/web/main.ts
@@ -1227,6 +1227,13 @@ class GitGraphView {
 				}
 			},
 			{
+				title: 'Copy short Commit Hash to Clipboard',
+				visible: visibility.copySubject,
+				onClick: () => {
+					sendMessage({ command: 'copyToClipboard', type: 'Commit Hash', data: abbrevCommit(hash) });
+				}
+			},
+			{
 				title: 'Copy Commit Subject to Clipboard',
 				visible: visibility.copySubject,
 				onClick: () => {


### PR DESCRIPTION
Summary of the issue:

Copying a commit hash via the context menu is awesome, but most of the time when telling someone to "please use commit X" you only really need the abbreviated short hash, so a new button in the context menu for the short hash should be added.

![image](https://user-images.githubusercontent.com/39636046/146422267-4d57fe28-75eb-48c5-a5f4-53604d2a995f.png)