### PR TITLE
fix(web): fix create file tree error when folder named constructor.

### DIFF
--- a/web/main.ts
+++ b/web/main.ts
@@ -2423,20 +2423,21 @@ class GitGraphView {
 			path = gitFiles[i].newFilePath.split('/');
 			absPath = this.currentRepo;
 			for (j = 0; j < path.length; j++) {
+				let contentName = 'graph-' + path[j];
 				absPath += '/' + path[j];
 				if (typeof this.gitRepos[absPath] !== 'undefined') {
-					if (typeof cur.contents[path[j]] === 'undefined') {
-						cur.contents[path[j]] = { type: 'repo', name: path[j], path: absPath };
+					if (typeof cur.contents[contentName] === 'undefined') {
+						cur.contents[contentName] = { type: 'repo', name: path[j], path: absPath };
 					}
 					break;
 				} else if (j < path.length - 1) {
-					if (typeof cur.contents[path[j]] === 'undefined') {
+					if (typeof cur.contents[contentName] === 'undefined') {
 						contents = {};
-						cur.contents[path[j]] = { type: 'folder', name: path[j], folderPath: absPath.substring(this.currentRepo.length + 1), contents: contents, open: true, reviewed: true };
+						cur.contents[contentName] = { type: 'folder', name: path[j], folderPath: absPath.substring(this.currentRepo.length + 1), contents: contents, open: true, reviewed: true };
 					}
-					cur = <FileTreeFolder>cur.contents[path[j]];
+					cur = <FileTreeFolder>cur.contents[contentName];
 				} else if (path[j] !== '') {
-					cur.contents[path[j]] = { type: 'file', name: path[j], index: i, reviewed: codeReview === null || !codeReview.remainingFiles.includes(gitFiles[i].newFilePath) };
+					cur.contents[contentName] = { type: 'file', name: path[j], index: i, reviewed: codeReview === null || !codeReview.remainingFiles.includes(gitFiles[i].newFilePath) };
 				}
 			}
 		}


### PR DESCRIPTION
Issue Number / Link: No

Summary of the issue:

If a directory in a project is called `constructor`, Commit Detail View always show loading.

Description outlining how this pull request resolves the issue:

normal directory:
<img width="814" alt="wecom-temp-2906404db59352c0d3af4970639f575a" src="https://user-images.githubusercontent.com/5382358/159682220-02036ebd-98d3-47ce-be51-d9f3764f1def.png">

wrong directory:
<img width="763" alt="wecom-temp-c7238f180e89d58b3c9942008bfaee2a" src="https://user-images.githubusercontent.com/5382358/159682373-1d20ed9c-9bad-4fd6-84a7-4ed563df0531.png">
<img width="643" alt="wecom-temp-e06f45d2280e4e1698ff14bb90e1de61" src="https://user-images.githubusercontent.com/5382358/159682398-90c50d15-5503-4e1c-8d0c-1136bf0dabc6.png">

because constructor and JS constructor have the same name:
<img width="557" alt="wecom-temp-f4f09d961f5262a7f7bacc2c5cc467d9" src="https://user-images.githubusercontent.com/5382358/159682453-a2066c85-b5e2-4cfe-ada4-317229433b04.png">

After modification:
<img width="807" alt="image" src="https://user-images.githubusercontent.com/5382358/159682943-359856a4-6a24-4855-ad09-c8c8fcb5dc7b.png">
<img width="1306" alt="image" src="https://user-images.githubusercontent.com/5382358/159683099-ace57d50-b89d-4470-a9f4-c0039555802c.png">
