### PR TITLE
Fix #641 by removing \r

### DIFF
--- a/src/dataSource.ts
+++ b/src/dataSource.ts
@@ -12,7 +12,7 @@ import { Disposable } from './utils/disposable';
 import { Event } from './utils/event';
 
 const DRIVE_LETTER_PATH_REGEX = /^[a-z]:\//;
-const EOL_REGEX = /\r\n|\r|\n/g;
+const EOL_REGEX = /\r\n|\n/g;
 const INVALID_BRANCH_REGEXP = /^\(.* .*\)$/;
 const REMOTE_HEAD_BRANCH_REGEXP = /^remotes\/.*\/HEAD$/;
 const GIT_LOG_SEPARATOR = 'XX7Nal-YARtTpjCikii9nJxER19D6diSyk-AWkPb';


### PR DESCRIPTION
**Issue Number / Link: #641** 

**Summary of the issue:**
The issue was that `\r` was being used to determine line endings, and in the https://github.com/rusoto/rusoto/commit/80fcb22489034a9fb1d28fc6ede3e9741f31d86e commit, they inputted `\r` in the message (I assume, judging by it saying 'usoto' not 'rusoto').

**Description outlining how this pull request resolves the issue:**
This fix removes `\r` from being a valid line ending, and as such, stops this from occuring again.

Alternatively, [this line](https://github.com/mhutchie/vscode-git-graph/blob/d7f43f429a9e024e896bac9fc65fdc530935c812/src/dataSource.ts#L1536) could be changed from a `break` to a `continue` which might prove to be more correct if `\r` is valid.