### PR TITLE
fix 645: add reverse order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ media
 node_modules
 out
 *.vsix
+yarn.lock
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "git-graph",
 	"displayName": "Git Graph",
-	"version": "1.30.0",
+	"version": "1.30.1",
 	"publisher": "mhutchie",
 	"author": {
 		"name": "Michael Hutchison",
@@ -1072,6 +1072,11 @@
 					"default": true,
 					"description": "Show Commits that are only referenced by tags in Git Graph."
 				},
+				"git-graph.repository.showReverseCommits": {
+					"type": "boolean",
+					"default": false,
+					"description": "Show Commits in reverse order by default. This can be overridden per repository from the Git Graph View's Control Bar."
+				},
 				"git-graph.repository.showRemoteBranches": {
 					"type": "boolean",
 					"default": true,
@@ -1515,7 +1520,7 @@
 		"vscode:prepublish": "npm run compile",
 		"vscode:uninstall": "node ./out/life-cycle/uninstall.js",
 		"clean": "node ./.vscode/clean.js",
-		"compile": "npm run lint && npm run clean && npm run compile-src && npm run compile-web",
+		"compile": "npm run lint && npm run clean && npm run compile-src && npm run compile-web-debug",
 		"compile-src": "tsc -p ./src && node ./.vscode/package-src.js",
 		"compile-web": "tsc -p ./web && node ./.vscode/package-web.js",
 		"compile-web-debug": "tsc -p ./web && node ./.vscode/package-web.js debug",

--- a/src/config.ts
+++ b/src/config.ts
@@ -458,6 +458,13 @@ class Config {
 	}
 
 	/**
+	 * Get the value of the `git-graph.repository.showReverseCommits` Extension Setting.
+	 */
+	 get showReverseCommits() {
+		return !!this.config.get('repository.showReverseCommits', false);
+	}
+
+	/**
 	 * Get the value of the `git-graph.repository.showRemoteBranches` Extension Setting.
 	 */
 	get showRemoteBranches() {

--- a/src/dataSource.ts
+++ b/src/dataSource.ts
@@ -12,7 +12,7 @@ import { Disposable } from './utils/disposable';
 import { Event } from './utils/event';
 
 const DRIVE_LETTER_PATH_REGEX = /^[a-z]:\//;
-const EOL_REGEX = /\r\n|\r|\n/g;
+const EOL_REGEX = /\r\n|\n/g;
 const INVALID_BRANCH_REGEXP = /^\(.* .*\)$/;
 const REMOTE_HEAD_BRANCH_REGEXP = /^remotes\/.*\/HEAD$/;
 const GIT_LOG_SEPARATOR = 'XX7Nal-YARtTpjCikii9nJxER19D6diSyk-AWkPb';

--- a/src/dataSource.ts
+++ b/src/dataSource.ts
@@ -12,7 +12,7 @@ import { Disposable } from './utils/disposable';
 import { Event } from './utils/event';
 
 const DRIVE_LETTER_PATH_REGEX = /^[a-z]:\//;
-const EOL_REGEX = /\r\n|\r|\n/g;
+const EOL_REGEX = /\r\n|\n/g;
 const INVALID_BRANCH_REGEXP = /^\(.* .*\)$/;
 const REMOTE_HEAD_BRANCH_REGEXP = /^remotes\/.*\/HEAD$/;
 const GIT_LOG_SEPARATOR = 'XX7Nal-YARtTpjCikii9nJxER19D6diSyk-AWkPb';
@@ -161,10 +161,10 @@ export class DataSource extends Disposable {
 	 * @param stashes An array of all stashes in the repository.
 	 * @returns The commits in the repository.
 	 */
-	public getCommits(repo: string, branches: ReadonlyArray<string> | null, maxCommits: number, showTags: boolean, showRemoteBranches: boolean, includeCommitsMentionedByReflogs: boolean, onlyFollowFirstParent: boolean, commitOrdering: CommitOrdering, remotes: ReadonlyArray<string>, hideRemotes: ReadonlyArray<string>, stashes: ReadonlyArray<GitStash>): Promise<GitCommitData> {
+	public getCommits(repo: string, branches: ReadonlyArray<string> | null, maxCommits: number, showTags: boolean, showReverseCommits: boolean, showRemoteBranches: boolean, includeCommitsMentionedByReflogs: boolean, onlyFollowFirstParent: boolean, commitOrdering: CommitOrdering, remotes: ReadonlyArray<string>, hideRemotes: ReadonlyArray<string>, stashes: ReadonlyArray<GitStash>): Promise<GitCommitData> {
 		const config = getConfig();
 		return Promise.all([
-			this.getLog(repo, branches, maxCommits + 1, showTags && config.showCommitsOnlyReferencedByTags, showRemoteBranches, includeCommitsMentionedByReflogs, onlyFollowFirstParent, commitOrdering, remotes, hideRemotes, stashes),
+			this.getLog(repo, branches, maxCommits + 1, showTags && config.showCommitsOnlyReferencedByTags, showReverseCommits, showRemoteBranches, includeCommitsMentionedByReflogs, onlyFollowFirstParent, commitOrdering, remotes, hideRemotes, stashes),
 			this.getRefs(repo, showRemoteBranches, config.showRemoteHeads, hideRemotes).then((refData: GitRefData) => refData, (errorMessage: string) => errorMessage)
 		]).then(async (results) => {
 			let commits: GitCommitRecord[] = results[0], refData: GitRefData | string = results[1], i;
@@ -188,7 +188,12 @@ export class DataSource extends Disposable {
 					if (refData.head === commits[i].hash) {
 						const numUncommittedChanges = await this.getUncommittedChanges(repo);
 						if (numUncommittedChanges > 0) {
-							commits.unshift({ hash: UNCOMMITTED, parents: [refData.head], author: '*', email: '', date: Math.round((new Date()).getTime() / 1000), message: 'Uncommitted Changes (' + numUncommittedChanges + ')' });
+							const cn = { hash: UNCOMMITTED, parents: [refData.head], author: '*', email: '', date: Math.round((new Date()).getTime() / 1000), message: 'Uncommitted Changes (' + numUncommittedChanges + ')' };
+							if (showReverseCommits) {
+								commits.push(cn);
+							} else {
+								commits.unshift(cn);
+							}
 						}
 						break;
 					}
@@ -204,6 +209,7 @@ export class DataSource extends Disposable {
 			}
 
 			/* Insert Stashes */
+			// OK for reverse order?
 			let toAdd: { index: number, data: GitStash }[] = [];
 			for (i = 0; i < stashes.length; i++) {
 				if (typeof commitLookup[stashes[i].hash] === 'number') {
@@ -264,7 +270,7 @@ export class DataSource extends Disposable {
 				commits: commitNodes,
 				head: refData.head,
 				tags: unique(refData.tags.map((tag) => tag.name)),
-				moreCommitsAvailable: moreCommitsAvailable,
+				moreCommitsAvailable: showReverseCommits ? false : moreCommitsAvailable,
 				error: null
 			};
 		}).catch((errorMessage) => {
@@ -1496,8 +1502,14 @@ export class DataSource extends Disposable {
 	 * @param stashes An array of all stashes in the repository.
 	 * @returns An array of commits.
 	 */
-	private getLog(repo: string, branches: ReadonlyArray<string> | null, num: number, includeTags: boolean, includeRemotes: boolean, includeCommitsMentionedByReflogs: boolean, onlyFollowFirstParent: boolean, order: CommitOrdering, remotes: ReadonlyArray<string>, hideRemotes: ReadonlyArray<string>, stashes: ReadonlyArray<GitStash>) {
-		const args = ['-c', 'log.showSignature=false', 'log', '--max-count=' + num, '--format=' + this.gitFormatLog, '--' + order + '-order'];
+	private getLog(repo: string, branches: ReadonlyArray<string> | null, num: number, includeTags: boolean, showReverseCommits: boolean, includeRemotes: boolean, includeCommitsMentionedByReflogs: boolean, onlyFollowFirstParent: boolean, order: CommitOrdering, remotes: ReadonlyArray<string>, hideRemotes: ReadonlyArray<string>, stashes: ReadonlyArray<GitStash>) {
+		let args = [];
+		if (showReverseCommits) {
+			args = ['-c', 'log.showSignature=false', 'log', '--format=' + this.gitFormatLog, '--date-order', '--reverse'];
+		} else {
+			args = ['-c', 'log.showSignature=false', 'log', '--max-count=' + num, '--format=' + this.gitFormatLog, '--' + order + '-order'];
+		}
+		// const args = ['-c', 'log.showSignature=false', 'log', '--max-count=' + num, '--format=' + this.gitFormatLog, '--' + order + '-order'];
 		if (onlyFollowFirstParent) {
 			args.push('--first-parent');
 		}

--- a/src/extensionState.ts
+++ b/src/extensionState.ts
@@ -32,6 +32,7 @@ export const DEFAULT_REPO_STATE: GitRepoState = {
 	onRepoLoadShowCheckedOutBranch: BooleanOverride.Default,
 	onRepoLoadShowSpecificBranches: null,
 	pullRequestConfig: null,
+	showReverseCommits: false,
 	showRemoteBranches: true,
 	showRemoteBranchesV2: BooleanOverride.Default,
 	showStashes: BooleanOverride.Default,

--- a/src/gitGraphView.ts
+++ b/src/gitGraphView.ts
@@ -409,7 +409,8 @@ export class GitGraphView extends Disposable {
 					command: 'loadCommits',
 					refreshId: msg.refreshId,
 					onlyFollowFirstParent: msg.onlyFollowFirstParent,
-					...await this.dataSource.getCommits(msg.repo, msg.branches, msg.maxCommits, msg.showTags, msg.showRemoteBranches, msg.includeCommitsMentionedByReflogs, msg.onlyFollowFirstParent, msg.commitOrdering, msg.remotes, msg.hideRemotes, msg.stashes)
+					showReverseCommits: msg.showReverseCommits,
+					...await this.dataSource.getCommits(msg.repo, msg.branches, msg.maxCommits, msg.showTags, msg.showReverseCommits, msg.showRemoteBranches, msg.includeCommitsMentionedByReflogs, msg.onlyFollowFirstParent, msg.commitOrdering, msg.remotes, msg.hideRemotes, msg.stashes)
 				});
 				break;
 			case 'loadConfig':
@@ -690,6 +691,7 @@ export class GitGraphView extends Disposable {
 				onRepoLoad: config.onRepoLoad,
 				referenceLabels: config.referenceLabels,
 				repoDropdownOrder: config.repoDropdownOrder,
+				showReverseCommits: config.showReverseCommits,
 				showRemoteBranches: config.showRemoteBranches,
 				showStashes: config.showStashes,
 				showTags: config.showTags
@@ -720,6 +722,7 @@ export class GitGraphView extends Disposable {
 				<div id="controls">
 					<span id="repoControl"><span class="unselectable">Repo: </span><div id="repoDropdown" class="dropdown"></div></span>
 					<span id="branchControl"><span class="unselectable">Branches: </span><div id="branchDropdown" class="dropdown"></div></span>
+					<label id="showReverseCommitsControl"><input type="checkbox" id="showReverseCommitsCheckbox" tabindex="-1"><span class="customCheckbox"></span>Reverse</label>
 					<label id="showRemoteBranchesControl"><input type="checkbox" id="showRemoteBranchesCheckbox" tabindex="-1"><span class="customCheckbox"></span>Show Remote Branches</label>
 					<div id="findBtn" title="Find"></div>
 					<div id="terminalBtn" title="Open a Terminal for this Repository"></div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 /* Git Interfaces / Types */
 
+
 export interface GitCommit {
 	readonly hash: string;
 	readonly parents: ReadonlyArray<string>;
@@ -212,6 +213,7 @@ export interface GitRepoState {
 	onRepoLoadShowCheckedOutBranch: BooleanOverride;
 	onRepoLoadShowSpecificBranches: string[] | null;
 	pullRequestConfig: PullRequestConfig | null;
+	showReverseCommits: boolean;
 	showRemoteBranches: boolean;
 	showRemoteBranchesV2: BooleanOverride;
 	showStashes: BooleanOverride;
@@ -257,6 +259,7 @@ export interface GitGraphViewConfig {
 	readonly onRepoLoad: OnRepoLoadConfig;
 	readonly referenceLabels: ReferenceLabelsConfig;
 	readonly repoDropdownOrder: RepoDropdownOrder;
+	readonly showReverseCommits: boolean;
 	readonly showRemoteBranches: boolean;
 	readonly showStashes: boolean;
 	readonly showTags: boolean;
@@ -904,6 +907,7 @@ export interface RequestLoadCommits extends RepoRequest {
 	readonly branches: ReadonlyArray<string> | null; // null => Show All
 	readonly maxCommits: number;
 	readonly showTags: boolean;
+	readonly showReverseCommits: boolean;
 	readonly showRemoteBranches: boolean;
 	readonly includeCommitsMentionedByReflogs: boolean;
 	readonly onlyFollowFirstParent: boolean;
@@ -920,6 +924,7 @@ export interface ResponseLoadCommits extends ResponseWithErrorInfo {
 	readonly tags: string[];
 	readonly moreCommitsAvailable: boolean;
 	readonly onlyFollowFirstParent: boolean;
+	readonly showReverseCommits: boolean;
 }
 
 export interface RequestLoadConfig extends RepoRequest {


### PR DESCRIPTION
- To add the support of viewing commits in reverse order

Issue Number / Link: Fixes #645

Summary of the issue: add the optional function: reverse order

Description outlining how this pull request resolves the issue:
> git log --date-order --reverse
> without paging setting

