### PR TITLE
New context menu action to restore a commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,6 +206,10 @@
 									"type": "boolean",
 									"title": "Create Branch..."
 								},
+								"restore": {
+									"type": "boolean",
+									"title": "Restore..."
+								},
 								"checkout": {
 									"type": "boolean",
 									"title": "Checkout..."
@@ -1537,7 +1541,7 @@
 		"eslint": "7.15.0",
 		"jest": "26.6.3",
 		"ts-jest": "26.4.4",
-		"typescript": "4.0.2",
+		"typescript": "4.1.5",
 		"uglify-js": "3.10.0"
 	}
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -82,7 +82,7 @@ class Config {
 		const userConfig = this.config.get('contextMenuActionsVisibility', {});
 		const config: ContextMenuActionsVisibility = {
 			branch: { checkout: true, rename: true, delete: true, merge: true, rebase: true, push: true, viewIssue: true, createPullRequest: true, createArchive: true, selectInBranchesDropdown: true, unselectInBranchesDropdown: true, copyName: true },
-			commit: { addTag: true, createBranch: true, checkout: true, cherrypick: true, revert: true, drop: true, merge: true, rebase: true, reset: true, copyHash: true, copySubject: true },
+			commit: { addTag: true, createBranch: true, restore: true, checkout: true, cherrypick: true, revert: true, drop: true, merge: true, rebase: true, reset: true, copyHash: true, copySubject: true },
 			commitDetailsViewFile: { viewDiff: true, viewFileAtThisRevision: true, viewDiffWithWorkingFile: true, openFile: true, markAsReviewed: true, markAsNotReviewed: true, resetFileToThisRevision: true, copyAbsoluteFilePath: true, copyRelativeFilePath: true },
 			remoteBranch: { checkout: true, delete: true, fetch: true, merge: true, pull: true, viewIssue: true, createPullRequest: true, createArchive: true, selectInBranchesDropdown: true, unselectInBranchesDropdown: true, copyName: true },
 			stash: { apply: true, createBranch: true, pop: true, drop: true, copyName: true, copyHash: true },

--- a/src/dataSource.ts
+++ b/src/dataSource.ts
@@ -1041,6 +1041,16 @@ export class DataSource extends Disposable {
 	/* Git Action Methods - Commits */
 
 	/**
+	 * Restore a commit in a repository.
+	 * @param repo The path of the repository.
+	 * @param commitHash The hash of the commit to check out.
+	 * @returns The ErrorInfo from the executed command.
+	 */
+	 public restoreCommit(repo: string, commitHash: string) {
+		return this.runGitCommand(['restore', '--source=' + commitHash, ':/'], repo);
+	}
+
+	/**
 	 * Checkout a commit in a repository.
 	 * @param repo The path of the repository.
 	 * @param commitHash The hash of the commit to check out.

--- a/src/extensionState.ts
+++ b/src/extensionState.ts
@@ -41,6 +41,7 @@ export const DEFAULT_REPO_STATE: GitRepoState = {
 
 const DEFAULT_GIT_GRAPH_VIEW_GLOBAL_STATE: GitGraphViewGlobalState = {
 	alwaysAcceptCheckoutCommit: false,
+	alwaysAcceptRestoreCommit: false,
 	issueLinkingConfig: null,
 	pushTagSkipRemoteCheck: false
 };

--- a/src/gitGraphView.ts
+++ b/src/gitGraphView.ts
@@ -215,6 +215,12 @@ export class GitGraphView extends Disposable {
 					errors: errorInfos
 				});
 				break;
+			case 'restoreCommit':
+				this.sendMessage({
+					command: 'restoreCommit',
+					error: await this.dataSource.restoreCommit(msg.repo, msg.commitHash)
+				});
+				break;
 			case 'checkoutCommit':
 				this.sendMessage({
 					command: 'checkoutCommit',

--- a/src/life-cycle/utils.ts
+++ b/src/life-cycle/utils.ts
@@ -107,7 +107,7 @@ export function getLifeCycleStateInDirectory(directory: string) {
  * @param state The state to save.
  */
 export function saveLifeCycleStateInDirectory(directory: string, state: LifeCycleState) {
-	return new Promise((resolve, reject) => {
+	return new Promise<void>((resolve, reject) => {
 		fs.mkdir(directory, (err) => {
 			if (!err || err.code === 'EEXIST') {
 				fs.writeFile(getLifeCycleFilePathInDirectory(directory), JSON.stringify(state), (err) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -264,6 +264,7 @@ export interface GitGraphViewConfig {
 
 export interface GitGraphViewGlobalState {
 	alwaysAcceptCheckoutCommit: boolean;
+	alwaysAcceptRestoreCommit: boolean;
 	issueLinkingConfig: IssueLinkingConfig | null;
 	pushTagSkipRemoteCheck: boolean;
 }
@@ -359,6 +360,7 @@ export interface ContextMenuActionsVisibility {
 	readonly commit: {
 		readonly addTag: boolean;
 		readonly createBranch: boolean;
+		readonly restore: boolean;
 		readonly checkout: boolean;
 		readonly cherrypick: boolean;
 		readonly revert: boolean;
@@ -1137,6 +1139,14 @@ export interface ResponseResetToCommit extends ResponseWithErrorInfo {
 	readonly command: 'resetToCommit';
 }
 
+export interface RequestRestoreCommit extends RepoRequest {
+	readonly command: 'restoreCommit';
+	readonly commitHash: string;
+}
+export interface ResponseRestoreCommit extends ResponseWithErrorInfo {
+	readonly command: 'restoreCommit';
+}
+
 export interface RequestRevertCommit extends RepoRequest {
 	readonly command: 'revertCommit';
 	readonly commitHash: string;
@@ -1298,6 +1308,7 @@ export type RequestMessage =
 	| RequestRescanForRepos
 	| RequestResetFileToRevision
 	| RequestResetToCommit
+	| RequestRestoreCommit
 	| RequestRevertCommit
 	| RequestSetGlobalViewState
 	| RequestSetRepoState
@@ -1362,6 +1373,7 @@ export type ResponseMessage =
 	| ResponseResetFileToRevision
 	| ResponseResetToCommit
 	| ResponseRevertCommit
+	| ResponseRestoreCommit
 	| ResponseSetGlobalViewState
 	| ResponseSetWorkspaceViewState
 	| ResponseStartCodeReview

--- a/web/main.ts
+++ b/web/main.ts
@@ -1111,6 +1111,22 @@ class GitGraphView {
 			}
 		], [
 			{
+				title: 'Restore' + (globalState.alwaysAcceptRestoreCommit ? '' : ELLIPSIS),
+				visible: visibility.restore,
+				onClick: () => {
+					const restoreCommit = () => runAction({ command: 'restoreCommit', repo: this.currentRepo, commitHash: hash }, 'Restore Commit');
+					if (globalState.alwaysAcceptRestoreCommit) {
+						restoreCommit();
+					} else {
+						dialog.showCheckbox('Are you sure you want to restore commit <b><i>' + abbrevCommit(hash) + '</i></b>?', 'Always Accept', false, 'Yes, restore', (alwaysAccept) => {
+							if (alwaysAccept) {
+								updateGlobalViewState('alwaysAcceptRestoreCommit', true);
+							}
+							restoreCommit();
+						}, target);
+					}
+				}
+			}, {
 				title: 'Checkout' + (globalState.alwaysAcceptCheckoutCommit ? '' : ELLIPSIS),
 				visible: visibility.checkout,
 				onClick: () => {
@@ -3371,6 +3387,9 @@ window.addEventListener('load', () => {
 				break;
 			case 'resetToCommit':
 				refreshOrDisplayError(msg.error, 'Unable to Reset to Commit');
+				break;
+			case 'restoreCommit':
+				refreshOrDisplayError(msg.error, 'Unable to Restore Commit');
 				break;
 			case 'revertCommit':
 				refreshOrDisplayError(msg.error, 'Unable to Revert Commit');


### PR DESCRIPTION
Summary of the issue:

Sometimes people prefer to manual merge, rather than to auto-merge and then resolve conflicts. In this case, `git restore` is useful. But currently we have no such option in git-graph.

Description outlining how this pull request resolves the issue:

Add a context menu to invoke `git restore` on a commit.
