### PR TITLE
Change activation to onStartupFinished

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"workspace"
 	],
 	"activationEvents": [
-		"*"
+		"onStartupFinished"
 	],
 	"main": "./out/extension.js",
 	"contributes": {


### PR DESCRIPTION
Same behavior as * but does not slow down vscode startup. There's no reason GistPad has to block extension loading.

https://code.visualstudio.com/api/references/activation-events#onStartupFinished
