### PR TITLE
Use VSCode 'log' language color to display Git Graph output

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -14,7 +14,7 @@ export class Logger extends Disposable {
 	 */
 	constructor() {
 		super();
-		this.channel = vscode.window.createOutputChannel('Git Graph');
+		this.channel = vscode.window.createOutputChannel('Git Graph', 'log');
 		this.registerDisposable(this.channel);
 	}
 


### PR DESCRIPTION
Summary of the issue: 
I noticed the second param of [`createOutputChannel`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/vscode/index.d.ts#L11502) (languageId) was not used.

Description outlining how this pull request resolves the issue:
I added  'log'  as second param to provide log style coloration in VSCode Git Graph output

before :
<img width="1491" height="224" alt="Screenshot from 2026-02-01 17-22-47" src="https://github.com/user-attachments/assets/bbe96798-a6fc-455c-806e-a6b66a49e47b" />
after:
<img width="1491" height="224" alt="Screenshot from 2026-02-01 17-21-57" src="https://github.com/user-attachments/assets/1d9206ad-d2bc-41ce-97fe-a8fcc8639826" />
